### PR TITLE
Fix marketplace ID and allow stopping scraper service

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -23,6 +23,7 @@ func main() {
 	application.Settings().SetTheme(theme.LightTheme())
 
 	service := scraper.NewService(25*time.Second, 25)
+	defer service.Close()
 
 	window := application.NewWindow("Amazon Product Intelligence Suite")
 	window.Resize(fyne.NewSize(1024, 720))


### PR DESCRIPTION
## Summary
- send the correct MarketID parameter to Amazon's completion API
- replace the rate limiter channel with a ticker and expose a Close helper to stop it
- ensure the desktop app stops the scraper service when shutting down

## Testing
- go test ./... *(fails: missing OpenGL/X11 development headers in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0a2b4bf883279a752daff875788a