### PR TITLE
Improve Amazon scraper timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ Options:
   --random-ua     Randomize user agent version. This helps to prevent request
                   blocking from the amazon side       [boolean] [default: false]
   --user-agent    Set custom user-agent                   [string] [default: ""]
-  --timeout, -t   Timeout between requests. Timeout is set in mls: 1000 mls = 1
-
+  --timeout, -t   Request timeout in milliseconds (1000 ms = 1 second)
+                                                      [number] [default: 15000]
 
 Examples:
   amazon-buddy products -k 'Xbox one'
@@ -859,8 +859,8 @@ const options = {
     //Randomize user agent version. This helps to prevent request blocking from the amazon side
     randomUa: false,
 
-    //Timeout between requests. Timeout is set in mls: 1000 mls = 1 second
-    timeout: 0,
+    //Request timeout in milliseconds (1000 ms = 1 second)
+    timeout: 15000,
 };
 ```
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -133,9 +133,9 @@ require('yargs')
         },
         timeout: {
             alias: 't',
-            default: 0,
+            default: 15000,
             type: 'number',
-            describe: 'Timeout between requests. Timeout is set in mls: 1000 mls = 1 second',
+            describe: 'Request timeout in milliseconds (default: 15000).',
         },
     })
     .check((argv) => {

--- a/lib/Amazon.js
+++ b/lib/Amazon.js
@@ -12,6 +12,15 @@ const { SocksProxyAgent } = require('socks-proxy-agent');
 
 const CONST = require('./constant');
 
+const DEFAULT_REQUEST_TIMEOUT = 15000;
+const RETRYABLE_STATUS_CODES = new Set([429, 503]);
+const TIMEOUT_ERROR_CODES = new Set(['ETIMEDOUT', 'ESOCKETTIMEDOUT']);
+const MAX_RETRY_ATTEMPTS = 4;
+const RETRY_BACKOFF_BASE_MS = 1000;
+const MAX_RETRY_DELAY_MS = 10000;
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 class AmazonScraper {
     constructor({
         keyword,
@@ -137,48 +146,67 @@ class AmazonScraper {
      * Main request method
      * @param {*} param0
      */
-    httpRequest({ uri, method, qs, json, body, form }) {
+    async httpRequest({ uri, method, qs, json, body, form }) {
         const proxy = this.getProxy;
-        return new Promise(async (resolve, reject) => {
-            const options = {
-                uri: uri ? `${this.mainHost}/${uri}` : this.mainHost,
-                method,
-                ...(qs ? { qs } : {}),
-                ...(body ? { body } : {}),
-                ...(form ? { form } : {}),
-                headers: {
-                    'user-agent': this.userAgent,
-                    cookie: this.cookie,
-                    accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
-                    'accept-language': 'en-US,en;q=0.9,ru;q=0.8',
-                    ...(this.getReferer ? { referer: this.getReferer } : {}),
-                    ...(Math.round(Math.random()) ? { downlink: Math.floor(Math.random() * 30) + 10 } : {}),
-                    ...(Math.round(Math.random()) ? { rtt: Math.floor(Math.random() * 100) + 50 } : {}),
-                    ...(Math.round(Math.random()) ? { pragma: 'no-cache' } : {}),
-                    ...(Math.round(Math.random()) ? { ect: '4g' } : {}),
-                    ...(Math.round(Math.random()) ? { DNT: 1 } : {}),
-                    'device-memory': `${Math.floor(Math.random() * 16) + 8}`,
-                    Referer: `${this.mainHost}?ref=nav_logo_${Math.floor(Math.random() * 10000000) + 1200}`,
-                    'device-memory': `${Math.floor(Math.random() * 16) + 6}`,
-                    'viewport-width': `${Math.floor(Math.random() * 2100) + 1200}`,
-                },
-                strictSSL: false,
-                ...(json ? { json: true } : {}),
-                gzip: true,
-                resolveWithFullResponse: true,
-                ...(proxy.proxy && proxy.socks ? { agent: proxy.proxy } : {}),
-                ...(proxy.proxy && !proxy.socks ? { proxy: `http://${proxy.proxy}/` } : {}),
-            };
+        const configuredTimeout = Number(this.timeout);
+        const requestTimeout = Number.isFinite(configuredTimeout) && configuredTimeout > 0 ? configuredTimeout : DEFAULT_REQUEST_TIMEOUT;
 
+        const options = {
+            uri: uri ? `${this.mainHost}/${uri}` : this.mainHost,
+            method,
+            ...(qs ? { qs } : {}),
+            ...(body ? { body } : {}),
+            ...(form ? { form } : {}),
+            headers: {
+                'user-agent': this.userAgent,
+                cookie: this.cookie,
+                accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+                'accept-language': 'en-US,en;q=0.9,ru;q=0.8',
+                ...(this.getReferer ? { referer: this.getReferer } : {}),
+                ...(Math.round(Math.random()) ? { downlink: Math.floor(Math.random() * 30) + 10 } : {}),
+                ...(Math.round(Math.random()) ? { rtt: Math.floor(Math.random() * 100) + 50 } : {}),
+                ...(Math.round(Math.random()) ? { pragma: 'no-cache' } : {}),
+                ...(Math.round(Math.random()) ? { ect: '4g' } : {}),
+                ...(Math.round(Math.random()) ? { DNT: 1 } : {}),
+                'device-memory': `${Math.floor(Math.random() * 16) + 8}`,
+                Referer: `${this.mainHost}?ref=nav_logo_${Math.floor(Math.random() * 10000000) + 1200}`,
+                'device-memory': `${Math.floor(Math.random() * 16) + 6}`,
+                'viewport-width': `${Math.floor(Math.random() * 2100) + 1200}`,
+            },
+            strictSSL: false,
+            ...(json ? { json: true } : {}),
+            gzip: true,
+            resolveWithFullResponse: true,
+            timeout: requestTimeout,
+            forever: false,
+            ...(proxy.proxy && proxy.socks ? { agent: proxy.proxy } : {}),
+            ...(proxy.proxy && !proxy.socks ? { proxy: `http://${proxy.proxy}/` } : {}),
+        };
+
+        return this.requestWithRetry(options);
+    }
+
+    async requestWithRetry(options) {
+        for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
             try {
-                const response = await rp(options);
-                setTimeout(() => {
-                    resolve(response);
-                }, this.timeout);
+                return await rp(options);
             } catch (error) {
-                reject(error);
+                const statusCode = error ? error.statusCode : null;
+                const causeCode = error && error.cause ? error.cause.code : null;
+                const nestedErrorCode = error && error.error ? error.error.code : null;
+                const isTimeoutError = TIMEOUT_ERROR_CODES.has(causeCode) || TIMEOUT_ERROR_CODES.has(nestedErrorCode);
+                const shouldRetry = isTimeoutError || RETRYABLE_STATUS_CODES.has(statusCode);
+
+                if (!shouldRetry || attempt === MAX_RETRY_ATTEMPTS) {
+                    throw error;
+                }
+
+                const backoffMs = Math.min(RETRY_BACKOFF_BASE_MS * 2 ** (attempt - 1), MAX_RETRY_DELAY_MS);
+                await delay(backoffMs);
             }
-        });
+        }
+
+        throw new Error('Request failed after maximum retry attempts');
     }
 
     /**


### PR DESCRIPTION
## Summary
- send request timeout configuration directly to request-promise with a sensible default and disable keep-alive
- add exponential backoff retry logic for throttling/timeouts to avoid hammering Amazon
- refresh CLI help text and README to describe the new timeout semantics and defaults

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd182511c48327a3fd22e0125f0f0f