### PR TITLE
Use ticker-based scraper rate limiting

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -23,6 +23,7 @@ func main() {
 	application.Settings().SetTheme(theme.LightTheme())
 
 	service := scraper.NewService(25*time.Second, 25)
+	defer service.Close()
 
 	window := application.NewWindow("Amazon Product Intelligence Suite")
 	window.Resize(fyne.NewSize(1024, 720))


### PR DESCRIPTION
## Summary
- replace the scraper service rate limiter with a stoppable time.Ticker and expose helper methods
- update request paths to wait on the ticker channel and abort when the service is closed
- close the scraper service when the GUI exits

## Testing
- go test ./... *(fails: missing OpenGL/X11 development libraries in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd184d27508327b684a16d8d336cd4