### PR TITLE
Add UI metric filters and scraper metadata for BookBeam-style workflows

### DIFF
--- a/internal/scraper/product.go
+++ b/internal/scraper/product.go
@@ -14,19 +14,35 @@ type ProductDetails struct {
 	ImageURL        string
 	Brand           string
 	DeliveryMessage string
+	Publisher       string
+	BestSellerRanks []BestSellerRank
+	IsIndependent   bool
+	TitleDensity    float64
 	FetchedAt       time.Time
 	URL             string
 }
 
+// BestSellerRank represents a single category ranking entry extracted from the
+// Amazon product detail page.
+type BestSellerRank struct {
+	Category string
+	Rank     int
+}
+
 // BestsellerProduct describes a product highlighted during bestseller analysis.
 type BestsellerProduct struct {
-	Rank        int
-	Title       string
-	ASIN        string
-	Price       string
-	Rating      string
-	ReviewCount string
-	URL         string
+	Rank         int
+	Title        string
+	ASIN         string
+	Price        string
+	Rating       string
+	ReviewCount  string
+	Publisher    string
+	BestSeller   int
+	Category     string
+	IsIndie      bool
+	TitleDensity float64
+	URL          string
 }
 
 // KeywordInsight captures keyword research related metrics.
@@ -35,6 +51,7 @@ type KeywordInsight struct {
 	SearchVolume     int
 	CompetitionScore float64
 	RelevancyScore   float64
+	TitleDensity     float64
 }
 
 // CategoryTrend contains aggregated category insights.
@@ -51,4 +68,17 @@ type InternationalKeyword struct {
 	CountryName  string
 	Keyword      string
 	SearchVolume int
+}
+
+// KeywordFilter defines optional threshold filters applied to keyword metrics.
+type KeywordFilter struct {
+	MinSearchVolume     int
+	MaxCompetitionScore float64
+	MaxTitleDensity     float64
+}
+
+// BestsellerFilter describes filters for bestseller search results.
+type BestsellerFilter struct {
+	MaxBestSellerRank int
+	IndependentOnly   bool
 }


### PR DESCRIPTION
## Summary
- add keyword and bestseller filter controls to the desktop UI with toggles for search volume, competition, title density, independent publishers, and BSR visibility
- extend scraper models to capture best seller ranks, publisher metadata, and heuristic title density scores while supporting keyword filtering on the backend
- enrich reverse ASIN and bestseller pipelines to honour the new filters and display title density/BSR information in the UI

## Testing
- go test ./... *(fails: missing system OpenGL/X11 headers required by fyne dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd69a611c08327802a69bf451fd3ff