### PR TITLE
Normalize country codes and tighten keyword generation

### DIFF
--- a/internal/scraper/country.go
+++ b/internal/scraper/country.go
@@ -1,5 +1,7 @@
 package scraper
 
+import "strings"
+
 // CountryConfig represents marketplace configuration for supported Amazon regions.
 type CountryConfig struct {
 	Country       string
@@ -42,7 +44,8 @@ func Countries() []string {
 // ConfigFor returns the marketplace configuration for the provided ISO Alpha-2 code.
 // When the country is unknown the function falls back to the United States marketplace.
 func ConfigFor(country string) CountryConfig {
-	if cfg, ok := countryConfigs[country]; ok {
+	normalized := strings.ToUpper(strings.TrimSpace(country))
+	if cfg, ok := countryConfigs[normalized]; ok {
 		return cfg
 	}
 	return countryConfigs["US"]

--- a/internal/scraper/service.go
+++ b/internal/scraper/service.go
@@ -467,10 +467,40 @@ func (s *Service) GenerateAMSKeywords(ctx context.Context, title, description st
 		return nil, errors.New("provide title, description or competitor keywords")
 	}
 
+	stopWords := map[string]struct{}{
+		"the":  {},
+		"and":  {},
+		"for":  {},
+		"you":  {},
+		"your": {},
+		"with": {},
+		"from": {},
+		"that": {},
+		"this": {},
+		"have": {},
+		"has":  {},
+		"are":  {},
+		"but":  {},
+		"not":  {},
+		"all":  {},
+		"any":  {},
+		"can":  {},
+		"our":  {},
+		"out":  {},
+		"one":  {},
+		"two":  {},
+	}
+
 	bag := map[string]int{}
 	add := func(token string, weight int) {
 		token = strings.ToLower(strings.TrimSpace(token))
 		if token == "" {
+			return
+		}
+		if len([]rune(token)) < 3 {
+			return
+		}
+		if _, skip := stopWords[token]; skip {
 			return
 		}
 		bag[token] += weight

--- a/lib/Amazon.js
+++ b/lib/Amazon.js
@@ -150,6 +150,7 @@ class AmazonScraper {
         const proxy = this.getProxy;
         const configuredTimeout = Number(this.timeout);
         const requestTimeout = Number.isFinite(configuredTimeout) && configuredTimeout > 0 ? configuredTimeout : DEFAULT_REQUEST_TIMEOUT;
+        const deviceMemory = Math.floor(Math.random() * 18) + 6;
 
         const options = {
             uri: uri ? `${this.mainHost}/${uri}` : this.mainHost,
@@ -168,9 +169,8 @@ class AmazonScraper {
                 ...(Math.round(Math.random()) ? { pragma: 'no-cache' } : {}),
                 ...(Math.round(Math.random()) ? { ect: '4g' } : {}),
                 ...(Math.round(Math.random()) ? { DNT: 1 } : {}),
-                'device-memory': `${Math.floor(Math.random() * 16) + 8}`,
+                'device-memory': `${deviceMemory}`,
                 Referer: `${this.mainHost}?ref=nav_logo_${Math.floor(Math.random() * 10000000) + 1200}`,
-                'device-memory': `${Math.floor(Math.random() * 16) + 6}`,
                 'viewport-width': `${Math.floor(Math.random() * 2100) + 1200}`,
             },
             strictSSL: false,


### PR DESCRIPTION
## Summary
- normalize incoming marketplace codes so lowercase values resolve to the correct configuration
- filter very short and stop-word tokens before hitting the keyword suggestion service
- consolidate device-memory header randomization in the legacy scraper

## Testing
- go test ./... *(fails: missing pkg-config GL and X11 development headers)*

------
https://chatgpt.com/codex/tasks/task_e_68cd752c0f28832790858795c313da9f