### PR TITLE
Fix completion API marketplace identifier

### DIFF
--- a/internal/scraper/service.go
+++ b/internal/scraper/service.go
@@ -228,7 +228,7 @@ func (s *Service) KeywordSuggestions(ctx context.Context, keyword, country strin
 	params.Set("page-type", "Search")
 	params.Set("client-info", "amazon-search-ui")
 	params.Set("limit", "15")
-	params.Set("mid", cfg.MarketplaceID)
+	params.Set("mid", cfg.MarketID)
 	params.Set("alias", "aps")
 	params.Set("suggestion-type", "KEYWORD")
 	params.Set("prefix", keyword)


### PR DESCRIPTION
## Summary
- use the configured market ID when calling the completion API so keyword suggestions resolve for every marketplace

## Testing
- go test ./... *(fails: missing OpenGL/X11 development libraries required by fyne dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7cb632348327bc63f0623443cd1d