### PR TITLE
docs: clarify 64-bit requirements for windows builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This fork adds a cross-platform desktop experience named **Amazon Product Intell
 
 ### Quick start
 
+> **Important:** The desktop UI depends on the [Fyne](https://fyne.io) toolkit which currently ships Windows binaries for **64-bit** environments only. Make sure you have the 64-bit Go toolchain installed (the Go installer adds `go env GOARCH` = `amd64`) and, if you rely on MinGW, that it is the `x86_64` variant. Attempting to compile with a 32-bit toolchain will lead to linker errors such as `cannot find -lgdi32` / `-lopengl32` because those libraries are not available for 386 builds.
+
 ```bash
 # run the UI locally
 go run ./cmd/app

--- a/docs/BUILD_WINDOWS.md
+++ b/docs/BUILD_WINDOWS.md
@@ -4,7 +4,7 @@ This repository now contains a Go/Fyne desktop application that wraps the scrapi
 
 ## 1. Prerequisites
 
-- Go **1.21** or newer installed locally.
+- Go **1.21** or newer installed locally. Install the **64-bit** distribution so that `go env GOARCH` reports `amd64`; the GUI cannot be built with 32-bit toolchains.
 - The [Fyne prerequisites](https://docs.fyne.io/started/) for your target platform. For Windows cross-compilation from Linux you also need a MinGW toolchain (`x86_64-w64-mingw32-gcc`).
 - Git and make (optional but convenient).
 - Inno Setup 6 (for building the installer) if you are on Windows.
@@ -32,7 +32,7 @@ GOOS=windows GOARCH=amd64 go build -o amazon-product-scraper.exe ./cmd/app
 
 The `fyne package` command embeds the required resources and produces an `.exe` file plus metadata. If you only need the executable, the `go build` command is sufficient.
 
-> **Note:** Fyne requires a C compiler. When cross-compiling from Linux you may have to install `mingw-w64` and set `CC=x86_64-w64-mingw32-gcc` before building.
+> **Note:** Fyne requires a C compiler. When cross-compiling from Linux you may have to install `mingw-w64` and set `CC=x86_64-w64-mingw32-gcc` before building. If you are developing on Windows, make sure the MinGW/MSYS2 environment you point to is the 64-bit `x86_64` variant. A 32-bit environment will fail during linking with messages such as `cannot find -lgdi32` and `cannot find -lopengl32`.
 
 ## 5. Package with Inno Setup
 


### PR DESCRIPTION
## Summary
- document that the desktop application requires a 64-bit Go/Fyne toolchain on Windows
- add troubleshooting guidance for the `cannot find -lgdi32`/`-lopengl32` linker errors seen with 32-bit environments

## Testing
- go test ./internal/...

------
https://chatgpt.com/codex/tasks/task_e_68cf895b7f488327b98a21afa70f5391