### PR TITLE
Implement desktop UI and licensing services

### DIFF
--- a/cmd/license-seeder/main.go
+++ b/cmd/license-seeder/main.go
@@ -15,6 +15,7 @@ import (
 func main() {
 	var (
 		apiBase    = flag.String("api-base", "", "base URL of the licensing API")
+		apiToken   = flag.String("api-token", "", "optional installer token override")
 		customerID = flag.String("customer", "", "unique customer identifier (email or order number)")
 		outputPath = flag.String("output", "", "optional path to also write the license key to")
 		appID      = flag.String("app-id", "amazon-product-suite", "application identifier used for storage")
@@ -30,7 +31,13 @@ func main() {
 		log.Fatalf("failed to read machine fingerprint: %v", err)
 	}
 
-	client := licenseclient.NewClient(*apiBase)
+	client, err := licenseclient.NewClient(*apiBase)
+	if err != nil {
+		log.Fatalf("failed to create license client: %v", err)
+	}
+	if strings.TrimSpace(*apiToken) != "" {
+		client.WithToken(*apiToken)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 

--- a/cmd/license-server/main.go
+++ b/cmd/license-server/main.go
@@ -18,6 +18,7 @@ func main() {
 		addr         = flag.String("addr", ":8080", "listen address for the HTTP server")
 		dbPath       = flag.String("db", "licenses.db", "path to the SQLite database")
 		expiryDays   = flag.Int("expiry", 365, "default license validity in days (0 for no expiry)")
+		installerTok = flag.String("token", os.Getenv("LICENSE_API_TOKEN"), "shared installer token (falls back to LICENSE_API_TOKEN)")
 		readTimeout  = flag.Duration("read-timeout", 10*time.Second, "HTTP server read timeout")
 		writeTimeout = flag.Duration("write-timeout", 10*time.Second, "HTTP server write timeout")
 		idleTimeout  = flag.Duration("idle-timeout", 60*time.Second, "HTTP server idle timeout")
@@ -32,6 +33,7 @@ func main() {
 	defer service.Close()
 
 	api := licensing.NewAPI(service)
+	api.SetInstallerToken(*installerTok)
 	mux := http.NewServeMux()
 	api.Register(mux)
 

--- a/go.sum
+++ b/go.sum
@@ -95,12 +95,16 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20211213063430-748e38ca8aec/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240306074159-ea2d69986ecb h1:S9I8pIVT5JHKDvmI1vQ0qs5fqxzUfhcZm/YbUC/8k1k=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240306074159-ea2d69986ecb/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-text/render v0.1.0 h1:osrmVDZNHuP1RSu3pNG7Z77Sd2xSbcb/xWytAj9kyVs=
 github.com/go-text/render v0.1.0/go.mod h1:jqEuNMenrmj6QRnkdpeaP0oKGFLDNhDkVKwGjsWWYU4=
 github.com/go-text/typesetting v0.1.0 h1:vioSaLPYcHwPEPLT7gsjCGDCoYSbljxoHJzMnKwVvHw=
 github.com/go-text/typesetting v0.1.0/go.mod h1:d22AnmeKq/on0HNv73UFriMKc4Ez6EqZAofLhAzpSzI=
+github.com/go-text/typesetting-utils v0.0.0-20240329101916-eee87fb235a3 h1:levTnuLLUmpavLGbJYLJA7fQnKeS7P1eCdAlM+vReXk=
+github.com/go-text/typesetting-utils v0.0.0-20240329101916-eee87fb235a3/go.mod h1:DDxDdQEnB70R8owOx3LVpEFvpMK9eeH1o2r0yZhFI9o=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -275,8 +279,10 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/tevino/abool v1.2.0 h1:heAkClL8H6w+mK5md9dzsuohKeXHUpY7Vw0ZCKW+huA=
 github.com/tevino/abool v1.2.0/go.mod h1:qc66Pna1RiIsPa7O4Egxxs9OqkuxDX55zznh9K07Tzg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/licenseclient/client.go
+++ b/internal/licenseclient/client.go
@@ -1,0 +1,160 @@
+package licenseclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/umar/amazon-product-scraper/internal/license"
+)
+
+// Envelope captures the details returned from the licensing API.
+type Envelope struct {
+	LicenseKey  string    `json:"licenseKey"`
+	CustomerID  string    `json:"customerId"`
+	Fingerprint string    `json:"fingerprint"`
+	IssuedAt    time.Time `json:"issuedAt"`
+	ExpiresAt   time.Time `json:"expiresAt,omitempty"`
+}
+
+// Client wraps the shared license HTTP client used by the installer utilities.
+type Client struct {
+	inner *license.Client
+}
+
+// NewClient constructs a client that communicates with the licensing API hosted at apiBase.
+// The LICENSE_API_TOKEN environment variable is automatically forwarded for authentication.
+func NewClient(apiBase string) (*Client, error) {
+	token := strings.TrimSpace(os.Getenv("LICENSE_API_TOKEN"))
+	httpClient := &http.Client{Timeout: 15 * time.Second}
+	inner, err := license.NewClient(strings.TrimSpace(apiBase), token, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{inner: inner}, nil
+}
+
+// WithToken overrides the installer token used for subsequent requests.
+func (c *Client) WithToken(token string) {
+	if c == nil || c.inner == nil {
+		return
+	}
+	c.inner.APIToken = strings.TrimSpace(token)
+}
+
+// Issue requests (or reuses) a license for the supplied fingerprint/customer combination.
+func (c *Client) Issue(ctx context.Context, fingerprint, customerID string) (*Envelope, error) {
+	if c == nil || c.inner == nil {
+		return nil, errors.New("licenseclient: client is not initialised")
+	}
+	fingerprint = strings.TrimSpace(fingerprint)
+	customerID = strings.TrimSpace(customerID)
+	if fingerprint == "" {
+		return nil, errors.New("licenseclient: fingerprint is required")
+	}
+	if customerID == "" {
+		return nil, errors.New("licenseclient: customer identifier is required")
+	}
+
+	key, err := c.inner.RequestLicense(ctx, customerID, fingerprint)
+	if err != nil {
+		return nil, err
+	}
+
+	env := &Envelope{
+		LicenseKey:  key,
+		CustomerID:  customerID,
+		Fingerprint: fingerprint,
+		IssuedAt:    time.Now().UTC(),
+	}
+	return env, nil
+}
+
+// Fingerprint returns the machine fingerprint used to bind licenses.
+func Fingerprint() (string, error) {
+	return license.Fingerprint()
+}
+
+// Storage persists and retrieves license keys on disk.
+type Storage struct {
+	path string
+}
+
+// NewStorage prepares a storage helper rooted inside the user's configuration directory.
+// The appID parameter determines the sub-directory used to isolate licenses for different products.
+func NewStorage(appID string) (*Storage, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return nil, fmt.Errorf("licenseclient: resolve config dir: %w", err)
+	}
+	appDir := filepath.Join(configDir, sanitizeAppID(appID))
+	if err := os.MkdirAll(appDir, 0o700); err != nil {
+		return nil, fmt.Errorf("licenseclient: create storage dir: %w", err)
+	}
+	return &Storage{path: filepath.Join(appDir, "license.key")}, nil
+}
+
+// Save writes the license key contained in the envelope to disk.
+func (s *Storage) Save(env *Envelope) error {
+	if s == nil {
+		return errors.New("licenseclient: storage is nil")
+	}
+	if env == nil {
+		return errors.New("licenseclient: envelope is nil")
+	}
+	key := strings.TrimSpace(env.LicenseKey)
+	if key == "" {
+		return errors.New("licenseclient: empty license key")
+	}
+	if err := os.WriteFile(s.path, []byte(key+"\n"), 0o600); err != nil {
+		return fmt.Errorf("licenseclient: write key: %w", err)
+	}
+	return nil
+}
+
+// Load retrieves the stored license key, trimming whitespace.
+func (s *Storage) Load() (string, error) {
+	if s == nil {
+		return "", errors.New("licenseclient: storage is nil")
+	}
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		return "", err
+	}
+	key := strings.TrimSpace(string(data))
+	if key == "" {
+		return "", errors.New("licenseclient: stored key is empty")
+	}
+	return key, nil
+}
+
+// Path exposes the absolute path to the persisted license key.
+func (s *Storage) Path() string {
+	if s == nil {
+		return ""
+	}
+	return s.path
+}
+
+func sanitizeAppID(appID string) string {
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return "AmazonProductSuite"
+	}
+	cleaned := make([]rune, 0, len(appID))
+	for _, r := range appID {
+		switch {
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-' || r == '_' || r == '.':
+			cleaned = append(cleaned, r)
+		}
+	}
+	if len(cleaned) == 0 {
+		return "AmazonProductSuite"
+	}
+	return string(cleaned)
+}

--- a/internal/licensing/api.go
+++ b/internal/licensing/api.go
@@ -1,0 +1,144 @@
+package licensing
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// API exposes HTTP handlers for issuing and validating licenses.
+type API struct {
+	service        *Service
+	installerToken string
+}
+
+// NewAPI constructs an API wrapper using the provided service. The installer token
+// is loaded from the LICENSE_API_TOKEN environment variable; applications can override
+// it later via SetInstallerToken.
+func NewAPI(service *Service) *API {
+	token := strings.TrimSpace(os.Getenv("LICENSE_API_TOKEN"))
+	return &API{service: service, installerToken: token}
+}
+
+// SetInstallerToken overrides the shared secret expected in the X-Installer-Token header.
+func (a *API) SetInstallerToken(token string) {
+	a.installerToken = strings.TrimSpace(token)
+}
+
+// Register attaches the API handlers to the provided multiplexer.
+func (a *API) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/v1/licenses", a.handleIssue)
+	mux.HandleFunc("/api/v1/licenses/validate", a.handleValidate)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+}
+
+func (a *API) handleIssue(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !a.authorize(w, r) {
+		return
+	}
+
+	var payload struct {
+		CustomerID  string `json:"customerId"`
+		Fingerprint string `json:"fingerprint"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid JSON payload", http.StatusBadRequest)
+		return
+	}
+
+	record, created, err := a.service.IssueLicense(r.Context(), payload.CustomerID, payload.Fingerprint)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	response := map[string]any{
+		"licenseKey": record.Key,
+		"issuedAt":   record.IssuedAt.UTC().Format(time.RFC3339),
+	}
+	if !record.ExpiresAt.IsZero() {
+		response["expiresAt"] = record.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+	if record.CustomerID != "" {
+		response["customerId"] = record.CustomerID
+	}
+
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(response)
+}
+
+func (a *API) handleValidate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !a.authorize(w, r) {
+		return
+	}
+
+	var payload struct {
+		LicenseKey  string `json:"licenseKey"`
+		Fingerprint string `json:"fingerprint"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid JSON payload", http.StatusBadRequest)
+		return
+	}
+
+	record, err := a.service.ValidateLicense(r.Context(), payload.LicenseKey, payload.Fingerprint)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrLicenseNotFound):
+			http.Error(w, "license not found", http.StatusUnauthorized)
+		case errors.Is(err, ErrFingerprintMismatch):
+			http.Error(w, "fingerprint mismatch", http.StatusUnauthorized)
+		case errors.Is(err, ErrLicenseExpired):
+			http.Error(w, "license expired", http.StatusUnauthorized)
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	response := map[string]any{
+		"status":     "valid",
+		"issuedAt":   record.IssuedAt.UTC().Format(time.RFC3339),
+		"customerId": record.CustomerID,
+	}
+	if !record.ExpiresAt.IsZero() {
+		response["expiresAt"] = record.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+func (a *API) authorize(w http.ResponseWriter, r *http.Request) bool {
+	if strings.TrimSpace(a.installerToken) == "" {
+		return true
+	}
+	provided := r.Header.Get("X-Installer-Token")
+	if subtle.ConstantTimeCompare([]byte(strings.TrimSpace(provided)), []byte(a.installerToken)) == 1 {
+		return true
+	}
+	http.Error(w, "forbidden", http.StatusForbidden)
+	return false
+}

--- a/internal/licensing/keygen.go
+++ b/internal/licensing/keygen.go
@@ -1,0 +1,79 @@
+package licensing
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+var keyAlphabet = []rune("ABCDEFGHJKLMNPQRSTUVWXYZ23456789")
+
+func sanitizeCustomerID(input string) string {
+	cleaned := make([]rune, 0, len(input))
+	for _, r := range strings.ToUpper(strings.TrimSpace(input)) {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			cleaned = append(cleaned, r)
+		case r >= '0' && r <= '9':
+			cleaned = append(cleaned, r)
+		}
+	}
+	if len(cleaned) == 0 {
+		return "CUSTOMER"
+	}
+	if len(cleaned) > 12 {
+		cleaned = cleaned[:12]
+	}
+	return string(cleaned)
+}
+
+// HashFingerprint normalises and hashes the fingerprint string.
+func HashFingerprint(raw string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(raw)))
+	return strings.ToUpper(hex.EncodeToString(sum[:]))
+}
+
+// GenerateLicenseKey composes a deterministic but hard-to-guess license key using
+// the fingerprint hash and customer identifier.
+func GenerateLicenseKey(customerID, fingerprintHash string) (string, error) {
+	sanitized := sanitizeCustomerID(customerID)
+	if len(fingerprintHash) < 12 {
+		return "", fmt.Errorf("licensing: fingerprint hash too short (%d)", len(fingerprintHash))
+	}
+	segment := func(start, end int) string { return fingerprintHash[start:end] }
+	rand1, err := randomSegment(5)
+	if err != nil {
+		return "", err
+	}
+	rand2, err := randomSegment(5)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s-%s-%s-%s-%s-%s",
+		sanitized,
+		segment(0, 4),
+		segment(4, 8),
+		segment(8, 12),
+		rand1,
+		rand2,
+	), nil
+}
+
+func randomSegment(length int) (string, error) {
+	if length <= 0 {
+		return "", fmt.Errorf("licensing: invalid segment length")
+	}
+	buf := make([]rune, length)
+	max := big.NewInt(int64(len(keyAlphabet)))
+	for i := 0; i < length; i++ {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", fmt.Errorf("licensing: random segment: %w", err)
+		}
+		buf[i] = keyAlphabet[int(n.Int64())]
+	}
+	return string(buf), nil
+}

--- a/internal/licensing/service.go
+++ b/internal/licensing/service.go
@@ -1,0 +1,244 @@
+package licensing
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+var (
+	// ErrLicenseNotFound indicates that no license row matches the lookup.
+	ErrLicenseNotFound = errors.New("licensing: license not found")
+	// ErrFingerprintMismatch is returned when a license key does not belong to the provided fingerprint.
+	ErrFingerprintMismatch = errors.New("licensing: fingerprint mismatch")
+	// ErrLicenseExpired is returned when the stored license has passed its expiry.
+	ErrLicenseExpired = errors.New("licensing: license expired")
+)
+
+// LicenseRecord represents a single license stored in the backing database.
+type LicenseRecord struct {
+	Key             string
+	FingerprintHash string
+	CustomerID      string
+	IssuedAt        time.Time
+	ExpiresAt       time.Time
+}
+
+// Service coordinates persistence and validation for license keys.
+type Service struct {
+	db            *sql.DB
+	defaultExpiry time.Duration
+}
+
+// NewService opens (or creates) the SQLite database used for licensing metadata.
+// The defaultExpiry parameter controls how long new licenses remain valid; pass zero
+// to indicate licenses should not expire automatically.
+func NewService(path string, defaultExpiry time.Duration) (*Service, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, errors.New("licensing: database path is required")
+	}
+	if path != ":memory:" {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return nil, fmt.Errorf("licensing: create database directory: %w", err)
+		}
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("licensing: open database: %w", err)
+	}
+
+	svc := &Service{db: db, defaultExpiry: defaultExpiry}
+	if err := svc.migrate(context.Background()); err != nil {
+		db.Close()
+		return nil, err
+	}
+	return svc, nil
+}
+
+// Close flushes and releases the underlying database resources.
+func (s *Service) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+// IssueLicense either returns the existing license for the fingerprint or mints
+// a new one when none exists or the previous license has expired.
+func (s *Service) IssueLicense(ctx context.Context, customerID, fingerprint string) (*LicenseRecord, bool, error) {
+	if s == nil {
+		return nil, false, errors.New("licensing: service is nil")
+	}
+	customerID = strings.TrimSpace(customerID)
+	fingerprint = strings.TrimSpace(fingerprint)
+	if customerID == "" {
+		return nil, false, errors.New("licensing: customer identifier is required")
+	}
+	if fingerprint == "" {
+		return nil, false, errors.New("licensing: fingerprint is required")
+	}
+
+	hash := HashFingerprint(fingerprint)
+	sanitized := sanitizeCustomerID(customerID)
+	now := time.Now().UTC()
+
+	existing, err := s.findByFingerprint(ctx, hash)
+	if err == nil {
+		if !existing.ExpiresAt.IsZero() && !existing.ExpiresAt.After(now) {
+			// The previous license expired; issue a replacement in-place.
+			return s.updateLicense(ctx, existing, sanitized, hash, now)
+		}
+		return existing, false, nil
+	}
+	if !errors.Is(err, ErrLicenseNotFound) {
+		return nil, false, err
+	}
+
+	key, err := GenerateLicenseKey(sanitized, hash)
+	if err != nil {
+		return nil, false, err
+	}
+	record := &LicenseRecord{
+		Key:             key,
+		FingerprintHash: hash,
+		CustomerID:      sanitized,
+		IssuedAt:        now,
+	}
+	if s.defaultExpiry > 0 {
+		record.ExpiresAt = now.Add(s.defaultExpiry)
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO licenses(key, fingerprint_hash, customer_id, issued_at, expires_at) VALUES(?, ?, ?, ?, ?)`,
+		record.Key, record.FingerprintHash, record.CustomerID, record.IssuedAt, nullTime(record.ExpiresAt),
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("licensing: insert license: %w", err)
+	}
+	return record, true, nil
+}
+
+// ValidateLicense confirms that the provided key belongs to the supplied fingerprint.
+func (s *Service) ValidateLicense(ctx context.Context, key, fingerprint string) (*LicenseRecord, error) {
+	if s == nil {
+		return nil, errors.New("licensing: service is nil")
+	}
+	key = strings.TrimSpace(key)
+	fingerprint = strings.TrimSpace(fingerprint)
+	if key == "" {
+		return nil, errors.New("licensing: license key is required")
+	}
+	if fingerprint == "" {
+		return nil, errors.New("licensing: fingerprint is required")
+	}
+
+	hash := HashFingerprint(fingerprint)
+	record, err := s.findByKey(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if record.FingerprintHash != hash {
+		return nil, ErrFingerprintMismatch
+	}
+	if !record.ExpiresAt.IsZero() && record.ExpiresAt.Before(time.Now()) {
+		return nil, ErrLicenseExpired
+	}
+	return record, nil
+}
+
+// updateLicense replaces the key for an existing fingerprint when the previous
+// license has expired.
+func (s *Service) updateLicense(ctx context.Context, existing *LicenseRecord, customerID, fingerprintHash string, issuedAt time.Time) (*LicenseRecord, bool, error) {
+	key, err := GenerateLicenseKey(customerID, fingerprintHash)
+	if err != nil {
+		return nil, false, err
+	}
+	expiresAt := time.Time{}
+	if s.defaultExpiry > 0 {
+		expiresAt = issuedAt.Add(s.defaultExpiry)
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE licenses SET key = ?, customer_id = ?, issued_at = ?, expires_at = ? WHERE fingerprint_hash = ?`,
+		key, customerID, issuedAt, nullTime(expiresAt), fingerprintHash,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("licensing: update license: %w", err)
+	}
+	existing.Key = key
+	existing.CustomerID = customerID
+	existing.IssuedAt = issuedAt
+	existing.ExpiresAt = expiresAt
+	return existing, true, nil
+}
+
+func (s *Service) migrate(ctx context.Context) error {
+	schema := `
+CREATE TABLE IF NOT EXISTS licenses (
+    key TEXT PRIMARY KEY,
+    fingerprint_hash TEXT NOT NULL UNIQUE,
+    customer_id TEXT NOT NULL,
+    issued_at TIMESTAMP NOT NULL,
+    expires_at TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_licenses_fingerprint ON licenses(fingerprint_hash);
+`
+	if _, err := s.db.ExecContext(ctx, schema); err != nil {
+		return fmt.Errorf("licensing: migrate schema: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) findByFingerprint(ctx context.Context, fingerprintHash string) (*LicenseRecord, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT key, fingerprint_hash, customer_id, issued_at, expires_at FROM licenses WHERE fingerprint_hash = ?`,
+		fingerprintHash,
+	)
+	record := &LicenseRecord{}
+	var expires sql.NullTime
+	if err := row.Scan(&record.Key, &record.FingerprintHash, &record.CustomerID, &record.IssuedAt, &expires); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrLicenseNotFound
+		}
+		return nil, fmt.Errorf("licensing: query fingerprint: %w", err)
+	}
+	if expires.Valid {
+		record.ExpiresAt = expires.Time
+	}
+	return record, nil
+}
+
+func (s *Service) findByKey(ctx context.Context, key string) (*LicenseRecord, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT key, fingerprint_hash, customer_id, issued_at, expires_at FROM licenses WHERE key = ?`,
+		key,
+	)
+	record := &LicenseRecord{}
+	var expires sql.NullTime
+	if err := row.Scan(&record.Key, &record.FingerprintHash, &record.CustomerID, &record.IssuedAt, &expires); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrLicenseNotFound
+		}
+		return nil, fmt.Errorf("licensing: query key: %w", err)
+	}
+	if expires.Valid {
+		record.ExpiresAt = expires.Time
+	}
+	return record, nil
+}
+
+func nullTime(value time.Time) interface{} {
+	if value.IsZero() {
+		return nil
+	}
+	return value
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1,6 +1,11 @@
+package ui
+
+import (
+	"context"
 	"encoding/csv"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"strconv"
 	"strings"
@@ -12,13 +17,15 @@
 	"fyne.io/fyne/v2/data/binding"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/layout"
-	"fyne.io/fyne/v2/storage"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 
 	"github.com/umar/amazon-product-scraper/internal/scraper"
 )
 
+const requestTimeout = 30 * time.Second
+
+// Run initialises and displays the desktop application.
 func Run() {
 	application := app.NewWithID("amazon-product-scraper")
 	application.Settings().SetTheme(theme.LightTheme())
@@ -67,3 +74,758 @@ func Run() {
 		container.NewTabItem("Competitive Analysis", buildCompetitiveTab(window, service, countries, reverseBinding, campaignBinding)),
 		container.NewTabItem("International", buildInternationalTab(window, service, countries, internationalBinding)),
 	)
+	tabs.SetTabLocation(container.TabLocationTop)
+
+	window.SetContent(tabs)
+	window.ShowAndRun()
+}
+
+func buildProductLookupTab(window fyne.Window, service *scraper.Service, countries []string, result binding.String) fyne.CanvasObject {
+	asinEntry := widget.NewEntry()
+	asinEntry.SetPlaceHolder("B08N5WRWNW")
+
+	countrySelect := widget.NewSelect(countries, nil)
+	if len(countries) > 0 {
+		countrySelect.SetSelected(countries[0])
+	}
+
+	resultLabel := widget.NewLabelWithData(result)
+	resultLabel.Wrapping = fyne.TextWrapWord
+
+	fetch := func() {
+		asin := strings.TrimSpace(asinEntry.Text)
+		country := strings.TrimSpace(countrySelect.Selected)
+		if asin == "" {
+			dialog.ShowInformation("Product Lookup", "Enter a valid ASIN to continue.", window)
+			return
+		}
+		if country == "" {
+			dialog.ShowInformation("Product Lookup", "Select the Amazon marketplace you wish to query.", window)
+			return
+		}
+
+		progress := dialog.NewProgressInfinite("Fetching Product", fmt.Sprintf("Looking up %s on %s…", strings.ToUpper(asin), strings.ToUpper(country)), window)
+		progress.Show()
+
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+			defer cancel()
+
+			details, err := service.FetchProduct(ctx, asin, country)
+
+			fyne.CurrentApp().Driver().RunOnMain(func() {
+				progress.Hide()
+				if err != nil {
+					dialog.ShowError(err, window)
+					safeSet(result, fmt.Sprintf("Unable to fetch product: %v", err))
+					return
+				}
+				safeSet(result, formatProductDetails(details))
+			})
+		}()
+	}
+
+	form := widget.NewForm(
+		widget.NewFormItem("ASIN", asinEntry),
+		widget.NewFormItem("Marketplace", countrySelect),
+	)
+	form.SubmitText = "Fetch Product"
+	form.OnSubmit = fetch
+
+	content := container.NewVBox(
+		form,
+		widget.NewSeparator(),
+		container.NewVScroll(container.NewPadded(resultLabel)),
+	)
+
+	return content
+}
+
+func buildKeywordResearchTab(window fyne.Window, service *scraper.Service, countries []string, keywordResult, categoryResult, bestsellerResult binding.String) fyne.CanvasObject {
+	keywordEntry := widget.NewEntry()
+	keywordEntry.SetPlaceHolder("children's book about space")
+
+	countrySelect := widget.NewSelect(countries, nil)
+	if len(countries) > 0 {
+		countrySelect.SetSelected(countries[0])
+	}
+
+	minVolumeEntry := widget.NewEntry()
+	minVolumeEntry.SetPlaceHolder("0")
+	maxCompetitionEntry := widget.NewEntry()
+	maxCompetitionEntry.SetPlaceHolder("1.0")
+	maxDensityEntry := widget.NewEntry()
+	maxDensityEntry.SetPlaceHolder("100")
+
+	maxRankEntry := widget.NewEntry()
+	maxRankEntry.SetPlaceHolder("50000")
+	indieOnlyCheck := widget.NewCheck("Indie authors only", nil)
+
+	keywordLabel := widget.NewLabelWithData(keywordResult)
+	keywordLabel.Wrapping = fyne.TextWrapWord
+	categoryLabel := widget.NewLabelWithData(categoryResult)
+	categoryLabel.Wrapping = fyne.TextWrapWord
+	bestsellerLabel := widget.NewLabelWithData(bestsellerResult)
+	bestsellerLabel.Wrapping = fyne.TextWrapWord
+
+	fetchKeywords := func() {
+		seed := strings.TrimSpace(keywordEntry.Text)
+		country := strings.TrimSpace(countrySelect.Selected)
+		if seed == "" {
+			dialog.ShowInformation("Keyword Research", "Enter a seed keyword to continue.", window)
+			return
+		}
+		if country == "" {
+			dialog.ShowInformation("Keyword Research", "Select a marketplace before running research.", window)
+			return
+		}
+
+		filters, err := parseKeywordFilter(minVolumeEntry.Text, maxCompetitionEntry.Text, maxDensityEntry.Text)
+		if err != nil {
+			dialog.ShowError(err, window)
+			return
+		}
+
+		progress := dialog.NewProgressInfinite("Keyword Research", fmt.Sprintf("Collecting ideas for \"%s\"…", seed), window)
+		progress.Show()
+
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+			defer cancel()
+
+			insights, err := service.KeywordSuggestions(ctx, seed, country, filters)
+
+			fyne.CurrentApp().Driver().RunOnMain(func() {
+				progress.Hide()
+				if err != nil {
+					dialog.ShowError(err, window)
+					safeSet(keywordResult, fmt.Sprintf("Unable to fetch keyword suggestions: %v", err))
+					return
+				}
+				safeSet(keywordResult, formatKeywordInsights(insights))
+			})
+		}()
+	}
+
+	fetchCategories := func() {
+		seed := strings.TrimSpace(keywordEntry.Text)
+		country := strings.TrimSpace(countrySelect.Selected)
+		if seed == "" {
+			dialog.ShowInformation("Category Insights", "Enter a seed keyword before analysing categories.", window)
+			return
+		}
+		if country == "" {
+			dialog.ShowInformation("Category Insights", "Select a marketplace before analysing categories.", window)
+			return
+		}
+
+		progress := dialog.NewProgressInfinite("Category Insights", "Discovering high performing categories…", window)
+		progress.Show()
+
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+			defer cancel()
+
+			trends, err := service.FetchCategoryTrends(ctx, seed, country)
+
+			fyne.CurrentApp().Driver().RunOnMain(func() {
+				progress.Hide()
+				if err != nil {
+					dialog.ShowError(err, window)
+					safeSet(categoryResult, fmt.Sprintf("Unable to fetch category insights: %v", err))
+					return
+				}
+				safeSet(categoryResult, formatCategoryTrends(trends))
+			})
+		}()
+	}
+
+	fetchBestsellers := func() {
+		seed := strings.TrimSpace(keywordEntry.Text)
+		country := strings.TrimSpace(countrySelect.Selected)
+		if seed == "" {
+			dialog.ShowInformation("Bestseller Snapshot", "Enter a keyword to analyse bestseller listings.", window)
+			return
+		}
+		if country == "" {
+			dialog.ShowInformation("Bestseller Snapshot", "Select a marketplace before analysing bestsellers.", window)
+			return
+		}
+
+		filter, err := parseBestsellerFilter(maxRankEntry.Text, indieOnlyCheck.Checked)
+		if err != nil {
+			dialog.ShowError(err, window)
+			return
+		}
+
+		progress := dialog.NewProgressInfinite("Bestseller Snapshot", fmt.Sprintf("Reviewing top results for \"%s\"…", seed), window)
+		progress.Show()
+
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+			defer cancel()
+
+			products, err := service.BestsellerAnalysis(ctx, seed, country, filter)
+
+			fyne.CurrentApp().Driver().RunOnMain(func() {
+				progress.Hide()
+				if err != nil {
+					dialog.ShowError(err, window)
+					safeSet(bestsellerResult, fmt.Sprintf("Unable to analyse bestsellers: %v", err))
+					return
+				}
+				safeSet(bestsellerResult, formatBestsellerProducts(products))
+			})
+		}()
+	}
+
+	keywordActions := container.NewHBox(
+		widget.NewButton("Fetch Keyword Suggestions", fetchKeywords),
+		widget.NewButton("Category Insights", fetchCategories),
+		widget.NewButton("Bestseller Snapshot", fetchBestsellers),
+	)
+
+	keywordOutputs := container.NewVScroll(container.NewVBox(
+		widget.NewLabelWithStyle("Keyword Suggestions", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		keywordLabel,
+		widget.NewSeparator(),
+		widget.NewLabelWithStyle("Category Intelligence", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		categoryLabel,
+		widget.NewSeparator(),
+		widget.NewLabelWithStyle("Bestseller Analysis", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		bestsellerLabel,
+	))
+
+	filtersForm := widget.NewForm(
+		widget.NewFormItem("Min Search Volume", minVolumeEntry),
+		widget.NewFormItem("Max Competition", maxCompetitionEntry),
+		widget.NewFormItem("Max Title Density", maxDensityEntry),
+		widget.NewFormItem("Max BSR", maxRankEntry),
+		widget.NewFormItem("Filters", indieOnlyCheck),
+	)
+
+	return container.NewBorder(filtersForm, nil, nil, nil, container.NewVBox(
+		widget.NewLabelWithStyle("Keyword Research Toolkit", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		keywordEntry,
+		countrySelect,
+		keywordActions,
+		layout.NewSpacer(),
+		keywordOutputs,
+	))
+}
+
+func buildCompetitiveTab(window fyne.Window, service *scraper.Service, countries []string, reverseResult, campaignResult binding.String) fyne.CanvasObject {
+	asinEntry := widget.NewEntry()
+	asinEntry.SetPlaceHolder("B0C1234XYZ")
+
+	countrySelect := widget.NewSelect(countries, nil)
+	if len(countries) > 0 {
+		countrySelect.SetSelected(countries[0])
+	}
+
+	minVolumeEntry := widget.NewEntry()
+	minVolumeEntry.SetPlaceHolder("0")
+	maxCompetitionEntry := widget.NewEntry()
+	maxCompetitionEntry.SetPlaceHolder("1.0")
+	maxDensityEntry := widget.NewEntry()
+	maxDensityEntry.SetPlaceHolder("100")
+
+	titleEntry := widget.NewEntry()
+	titleEntry.SetPlaceHolder("Book title or product headline")
+	descriptionEntry := widget.NewMultiLineEntry()
+	descriptionEntry.SetPlaceHolder("Paste your blurb or key selling points here…")
+	competitorEntry := widget.NewMultiLineEntry()
+	competitorEntry.SetPlaceHolder("Comma separated competitor keywords or ASIN phrases")
+
+	reverseLabel := widget.NewLabelWithData(reverseResult)
+	reverseLabel.Wrapping = fyne.TextWrapWord
+	campaignLabel := widget.NewLabelWithData(campaignResult)
+	campaignLabel.Wrapping = fyne.TextWrapWord
+
+	reverseButton := widget.NewButton("Run Reverse ASIN", func() {
+		asin := strings.TrimSpace(asinEntry.Text)
+		country := strings.TrimSpace(countrySelect.Selected)
+		if asin == "" {
+			dialog.ShowInformation("Reverse ASIN", "Provide an ASIN to analyse.", window)
+			return
+		}
+		if country == "" {
+			dialog.ShowInformation("Reverse ASIN", "Select a marketplace before analysing.", window)
+			return
+		}
+
+		filters, err := parseKeywordFilter(minVolumeEntry.Text, maxCompetitionEntry.Text, maxDensityEntry.Text)
+		if err != nil {
+			dialog.ShowError(err, window)
+			return
+		}
+
+		progress := dialog.NewProgressInfinite("Reverse ASIN", fmt.Sprintf("Investigating %s…", strings.ToUpper(asin)), window)
+		progress.Show()
+
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+			defer cancel()
+
+			insights, err := service.ReverseASINSearch(ctx, asin, country, filters)
+
+			fyne.CurrentApp().Driver().RunOnMain(func() {
+				progress.Hide()
+				if err != nil {
+					dialog.ShowError(err, window)
+					safeSet(reverseResult, fmt.Sprintf("Unable to run reverse ASIN: %v", err))
+					return
+				}
+				safeSet(reverseResult, formatKeywordInsights(insights))
+			})
+		}()
+	})
+
+	campaignButton := widget.NewButton("Generate Campaign Keywords", func() {
+		country := strings.TrimSpace(countrySelect.Selected)
+		if country == "" {
+			dialog.ShowInformation("Campaign Builder", "Select a marketplace to generate keywords.", window)
+			return
+		}
+
+		competitors, err := parseCSVKeywords(competitorEntry.Text)
+		if err != nil {
+			dialog.ShowError(fmt.Errorf("unable to parse competitor keywords: %w", err), window)
+			return
+		}
+
+		progress := dialog.NewProgressInfinite("Campaign Builder", "Composing Amazon Ads keyword list…", window)
+		progress.Show()
+
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+			defer cancel()
+
+			keywords, err := service.GenerateAMSKeywords(ctx, titleEntry.Text, descriptionEntry.Text, competitors, country)
+
+			fyne.CurrentApp().Driver().RunOnMain(func() {
+				progress.Hide()
+				if err != nil {
+					dialog.ShowError(err, window)
+					safeSet(campaignResult, fmt.Sprintf("Unable to generate campaign keywords: %v", err))
+					return
+				}
+				safeSet(campaignResult, formatCampaignKeywords(keywords))
+			})
+		}()
+	})
+
+	reverseSection := container.NewVBox(
+		widget.NewLabelWithStyle("Reverse ASIN Intelligence", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		asinEntry,
+		container.NewGridWithColumns(3, minVolumeEntry, maxCompetitionEntry, maxDensityEntry),
+		reverseButton,
+		widget.NewSeparator(),
+		container.NewVScroll(reverseLabel),
+	)
+
+	campaignSection := container.NewVBox(
+		widget.NewLabelWithStyle("Amazon Ads Planner", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		titleEntry,
+		descriptionEntry,
+		competitorEntry,
+		campaignButton,
+		widget.NewSeparator(),
+		container.NewVScroll(campaignLabel),
+	)
+
+	sidebar := widget.NewForm(
+		widget.NewFormItem("Marketplace", countrySelect),
+	)
+
+	return container.NewBorder(sidebar, nil, nil, nil, container.NewVBox(reverseSection, widget.NewSeparator(), campaignSection))
+}
+
+func buildInternationalTab(window fyne.Window, service *scraper.Service, countries []string, result binding.String) fyne.CanvasObject {
+	keywordEntry := widget.NewEntry()
+	keywordEntry.SetPlaceHolder("mindfulness journal")
+
+	countryGroup := widget.NewCheckGroup(countries, nil)
+	defaults := defaultInternationalSelection(countries)
+	if len(defaults) > 0 {
+		countryGroup.SetSelected(defaults)
+	}
+
+	resultLabel := widget.NewLabelWithData(result)
+	resultLabel.Wrapping = fyne.TextWrapWord
+
+	fetch := func() {
+		keyword := strings.TrimSpace(keywordEntry.Text)
+		if keyword == "" {
+			dialog.ShowInformation("International Research", "Enter a seed keyword to continue.", window)
+			return
+		}
+
+		selected := countryGroup.Selected
+		if len(selected) == 0 {
+			dialog.ShowInformation("International Research", "Select at least one marketplace to analyse.", window)
+			return
+		}
+
+		progress := dialog.NewProgressInfinite("International Research", "Localising your keyword list…", window)
+		progress.Show()
+
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+			defer cancel()
+
+			keywords, err := service.InternationalKeywords(ctx, keyword, selected)
+
+			fyne.CurrentApp().Driver().RunOnMain(func() {
+				progress.Hide()
+				if err != nil {
+					dialog.ShowError(err, window)
+					safeSet(result, fmt.Sprintf("Unable to fetch international keywords: %v", err))
+					return
+				}
+				safeSet(result, formatInternationalKeywords(keywords))
+			})
+		}()
+	}
+
+	return container.NewVBox(
+		widget.NewLabelWithStyle("International Keyword Expansion", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		keywordEntry,
+		countryGroup,
+		widget.NewButton("Generate Suggestions", fetch),
+		widget.NewSeparator(),
+		container.NewVScroll(resultLabel),
+	)
+}
+
+func formatProductDetails(details *scraper.ProductDetails) string {
+	if details == nil {
+		return "No product details were returned."
+	}
+
+	builder := &strings.Builder{}
+	fmt.Fprintf(builder, "%s (%s)\n", fallback(details.Title, "Unknown Title"), strings.ToUpper(fallback(details.ASIN, "N/A")))
+	if details.Price != "" || details.Currency != "" {
+		fmt.Fprintf(builder, "Price: %s %s\n", fallback(details.Currency, "$"), fallback(details.Price, "0.00"))
+	}
+	if details.Rating != "" || details.ReviewCount != "" {
+		fmt.Fprintf(builder, "Rating: %s (%s reviews)\n", fallback(details.Rating, "N/A"), fallback(details.ReviewCount, "0"))
+	}
+	if details.Availability != "" {
+		fmt.Fprintf(builder, "Availability: %s\n", details.Availability)
+	}
+	if details.DeliveryMessage != "" {
+		fmt.Fprintf(builder, "Delivery: %s\n", details.DeliveryMessage)
+	}
+	if details.Brand != "" {
+		fmt.Fprintf(builder, "Brand: %s\n", details.Brand)
+	}
+	if details.Publisher != "" {
+		fmt.Fprintf(builder, "Publisher: %s\n", details.Publisher)
+	}
+	if details.PublicationDate != "" {
+		fmt.Fprintf(builder, "Publication Date: %s\n", details.PublicationDate)
+	}
+	if details.PrintLength != "" {
+		fmt.Fprintf(builder, "Length: %s\n", details.PrintLength)
+	}
+	if details.Dimensions != "" {
+		fmt.Fprintf(builder, "Dimensions: %s\n", details.Dimensions)
+	}
+	if details.Language != "" {
+		fmt.Fprintf(builder, "Language: %s\n", details.Language)
+	}
+	if details.ISBN10 != "" || details.ISBN13 != "" {
+		fmt.Fprintf(builder, "ISBN-10: %s | ISBN-13: %s\n", fallback(details.ISBN10, "N/A"), fallback(details.ISBN13, "N/A"))
+	}
+	if details.TitleDensity > 0 {
+		fmt.Fprintf(builder, "Title Density: %.2f\n", details.TitleDensity)
+	}
+	if len(details.BestSellerRanks) > 0 {
+		sort.SliceStable(details.BestSellerRanks, func(i, j int) bool {
+			return details.BestSellerRanks[i].Rank < details.BestSellerRanks[j].Rank
+		})
+		builder.WriteString("\nBestseller Ranks:\n")
+		for _, rank := range details.BestSellerRanks {
+			fmt.Fprintf(builder, "  • #%d in %s\n", rank.Rank, rank.Category)
+		}
+	}
+	if !details.FetchedAt.IsZero() {
+		fmt.Fprintf(builder, "\nLast Checked: %s\n", details.FetchedAt.Local().Format(time.RFC1123))
+	}
+	if details.URL != "" {
+		fmt.Fprintf(builder, "Listing URL: %s\n", details.URL)
+	}
+	if details.IsIndependent {
+		builder.WriteString("Publisher Type: Independent\n")
+	}
+
+	output := strings.TrimSpace(builder.String())
+	if output == "" {
+		return "No product details were returned."
+	}
+	return output
+}
+
+func formatKeywordInsights(insights []scraper.KeywordInsight) string {
+	if len(insights) == 0 {
+		return "No keyword insights available. Try broadening your filters."
+	}
+
+	sorted := append([]scraper.KeywordInsight(nil), insights...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].SearchVolume == sorted[j].SearchVolume {
+			return sorted[i].Keyword < sorted[j].Keyword
+		}
+		return sorted[i].SearchVolume > sorted[j].SearchVolume
+	})
+
+	builder := &strings.Builder{}
+	for index, insight := range sorted {
+		fmt.Fprintf(builder, "%d. %s\n", index+1, insight.Keyword)
+		fmt.Fprintf(builder, "   Search Volume: %d\n", insight.SearchVolume)
+		fmt.Fprintf(builder, "   Competition: %.2f | Relevancy: %.2f | Title Density: %.2f\n\n", insight.CompetitionScore, insight.RelevancyScore, insight.TitleDensity)
+	}
+
+	return strings.TrimSpace(builder.String())
+}
+
+func formatCategoryTrends(trends []scraper.CategoryTrend) string {
+	if len(trends) == 0 {
+		return "No category signals discovered."
+	}
+
+	sorted := append([]scraper.CategoryTrend(nil), trends...)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Rank < sorted[j].Rank })
+
+	builder := &strings.Builder{}
+	for _, trend := range sorted {
+		fmt.Fprintf(builder, "%s (Top #%d)\n", trend.Category, trend.Rank)
+		if trend.Momentum != "" {
+			fmt.Fprintf(builder, "   Momentum: %s\n", trend.Momentum)
+		}
+		if trend.Notes != "" {
+			fmt.Fprintf(builder, "   Notes: %s\n", trend.Notes)
+		}
+		builder.WriteString("\n")
+	}
+
+	return strings.TrimSpace(builder.String())
+}
+
+func formatBestsellerProducts(products []scraper.BestsellerProduct) string {
+	if len(products) == 0 {
+		return "No bestseller data available for the current keyword."
+	}
+
+	sorted := append([]scraper.BestsellerProduct(nil), products...)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Rank < sorted[j].Rank })
+
+	builder := &strings.Builder{}
+	for _, product := range sorted {
+		fmt.Fprintf(builder, "#%d %s (%s)\n", product.Rank, product.Title, product.ASIN)
+		if product.Price != "" {
+			fmt.Fprintf(builder, "   Price: %s\n", product.Price)
+		}
+		if product.Rating != "" || product.ReviewCount != "" {
+			fmt.Fprintf(builder, "   Rating: %s (%s reviews)\n", fallback(product.Rating, "N/A"), fallback(product.ReviewCount, "0"))
+		}
+		if product.BestSeller > 0 && product.Category != "" {
+			fmt.Fprintf(builder, "   Category: #%d in %s\n", product.BestSeller, product.Category)
+		}
+		if product.Publisher != "" {
+			fmt.Fprintf(builder, "   Publisher: %s\n", product.Publisher)
+		}
+		if product.IsIndie {
+			builder.WriteString("   Independent Author Highlight\n")
+		}
+		if product.TitleDensity > 0 {
+			fmt.Fprintf(builder, "   Title Density: %.2f\n", product.TitleDensity)
+		}
+		if product.URL != "" {
+			fmt.Fprintf(builder, "   URL: %s\n", product.URL)
+		}
+		builder.WriteString("\n")
+	}
+
+	return strings.TrimSpace(builder.String())
+}
+
+func formatCampaignKeywords(keywords []string) string {
+	if len(keywords) == 0 {
+		return "No campaign keywords generated. Provide more metadata or competitor insights."
+	}
+
+	flagged := scraper.FlagIllegalKeywords(keywords)
+	flaggedSet := map[string]struct{}{}
+	for _, keyword := range flagged {
+		flaggedSet[strings.ToLower(keyword)] = struct{}{}
+	}
+
+	builder := &strings.Builder{}
+	fmt.Fprintf(builder, "Generated %d keyword(s):\n", len(keywords))
+	for index, keyword := range keywords {
+		marker := ""
+		if _, exists := flaggedSet[strings.ToLower(keyword)]; exists {
+			marker = " ⚠️"
+		}
+		fmt.Fprintf(builder, "%d. %s%s\n", index+1, keyword, marker)
+	}
+
+	if len(flagged) > 0 {
+		builder.WriteString("\n⚠️ Keywords flagged for compliance review:\n")
+		for _, keyword := range flagged {
+			fmt.Fprintf(builder, "   • %s\n", keyword)
+		}
+	}
+
+	return strings.TrimSpace(builder.String())
+}
+
+func formatInternationalKeywords(keywords []scraper.InternationalKeyword) string {
+	if len(keywords) == 0 {
+		return "No international opportunities found yet. Try selecting more marketplaces."
+	}
+
+	sorted := append([]scraper.InternationalKeyword(nil), keywords...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].CountryCode == sorted[j].CountryCode {
+			return sorted[i].SearchVolume > sorted[j].SearchVolume
+		}
+		return sorted[i].CountryCode < sorted[j].CountryCode
+	})
+
+	builder := &strings.Builder{}
+	current := ""
+	for _, keyword := range sorted {
+		if keyword.CountryCode != current {
+			if current != "" {
+				builder.WriteString("\n")
+			}
+			name := keyword.CountryName
+			if name == "" {
+				name = keyword.CountryCode
+			}
+			fmt.Fprintf(builder, "%s (%s)\n", name, strings.ToUpper(keyword.CountryCode))
+			current = keyword.CountryCode
+		}
+		fmt.Fprintf(builder, "  • %s — volume %d\n", keyword.Keyword, keyword.SearchVolume)
+	}
+
+	return strings.TrimSpace(builder.String())
+}
+
+func parseKeywordFilter(minVolume, maxCompetition, maxDensity string) (scraper.KeywordFilter, error) {
+	filter := scraper.KeywordFilter{}
+
+	if trimmed := strings.TrimSpace(minVolume); trimmed != "" {
+		value, err := strconv.Atoi(trimmed)
+		if err != nil {
+			return filter, fmt.Errorf("invalid minimum search volume: %w", err)
+		}
+		if value < 0 {
+			return filter, errors.New("minimum search volume cannot be negative")
+		}
+		filter.MinSearchVolume = value
+	}
+
+	if trimmed := strings.TrimSpace(maxCompetition); trimmed != "" {
+		value, err := strconv.ParseFloat(trimmed, 64)
+		if err != nil {
+			return filter, fmt.Errorf("invalid maximum competition score: %w", err)
+		}
+		if value < 0 {
+			return filter, errors.New("maximum competition score cannot be negative")
+		}
+		filter.MaxCompetitionScore = value
+	}
+
+	if trimmed := strings.TrimSpace(maxDensity); trimmed != "" {
+		value, err := strconv.ParseFloat(trimmed, 64)
+		if err != nil {
+			return filter, fmt.Errorf("invalid maximum title density: %w", err)
+		}
+		if value < 0 {
+			return filter, errors.New("maximum title density cannot be negative")
+		}
+		filter.MaxTitleDensity = value
+	}
+
+	return filter, nil
+}
+
+func parseBestsellerFilter(maxRank string, indieOnly bool) (scraper.BestsellerFilter, error) {
+	filter := scraper.BestsellerFilter{IndependentOnly: indieOnly}
+	if trimmed := strings.TrimSpace(maxRank); trimmed != "" {
+		value, err := strconv.Atoi(trimmed)
+		if err != nil {
+			return filter, fmt.Errorf("invalid max bestseller rank: %w", err)
+		}
+		if value < 0 {
+			return filter, errors.New("max bestseller rank cannot be negative")
+		}
+		filter.MaxBestSellerRank = value
+	}
+	return filter, nil
+}
+
+func parseCSVKeywords(input string) ([]string, error) {
+	reader := csv.NewReader(strings.NewReader(input))
+	reader.FieldsPerRecord = -1
+
+	keywords := []string{}
+	for {
+		record, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		for _, field := range record {
+			token := strings.TrimSpace(field)
+			if token != "" {
+				keywords = append(keywords, token)
+			}
+		}
+	}
+	return keywords, nil
+}
+
+func fallback(value, alt string) string {
+	if strings.TrimSpace(value) == "" {
+		return alt
+	}
+	return value
+}
+
+func safeSet(target binding.String, value string) {
+	if err := target.Set(value); err != nil {
+		fyne.LogError("failed to update binding", err)
+	}
+}
+
+func defaultInternationalSelection(countries []string) []string {
+	preferred := []string{"US", "UK", "CA", "DE", "AU"}
+	selection := []string{}
+	seen := map[string]struct{}{}
+	for _, code := range countries {
+		upper := strings.ToUpper(code)
+		for _, pref := range preferred {
+			if upper == strings.ToUpper(pref) {
+				if _, exists := seen[upper]; !exists {
+					selection = append(selection, code)
+					seen[upper] = struct{}{}
+				}
+			}
+		}
+	}
+	if len(selection) == 0 && len(countries) > 0 {
+		limit := len(countries)
+		if limit > 3 {
+			limit = 3
+		}
+		selection = append(selection, countries[:limit]...)
+	}
+	return selection
+}


### PR DESCRIPTION
## Summary
- rebuild the Fyne desktop UI to provide product lookup, keyword research, competitive analysis, and international research workflows
- add a reusable licensing service and HTTP API for issuing and validating license keys backed by SQLite
- supply a client/helper package and update the CLI utilities to issue and store licenses using the shared code

## Testing
- go test ./... *(fails: missing OpenGL/X11 development libraries in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c2e408148327887bc61760f431e8