### PR TITLE
docs: refresh windows build and licensing prerequisites

### DIFF
--- a/docs/license-system-guide.md
+++ b/docs/license-system-guide.md
@@ -15,7 +15,7 @@ The document is self-contained so that you can integrate licensing without needi
 | --- | --- |
 | Installer tooling | [Inno Setup 6+](https://jrsoftware.org/isinfo.php) with the built-in script editor or Inno Script Studio. |
 | Desktop binary | Windows build of your Go/Fyne application (e.g. `GOOS=windows GOARCH=amd64 go build ./cmd/app`). |
-| Backend | Go 1.21+, SQLite 3 (or preferred DB), and ability to expose an HTTPS endpoint. |
+| Backend | Go 1.23+ (the module pins toolchain Go 1.24.3), SQLite 3 (or preferred DB), and ability to expose an HTTPS endpoint. |
 | Networking | Outbound HTTPS connectivity from installers and clients to your API domain. |
 | Security | Access to Windows Credential Locker or DPAPI if you plan to encrypt stored keys. |
 


### PR DESCRIPTION
## Summary
- update the Windows build guide to reflect the Go 1.24 toolchain, require the Fyne CLI, and place executables in `bin/`
- clarify how to compile the fingerprint helper alongside the desktop app
- bump the licensing guide backend prerequisite to Go 1.23+

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0c6e777188327b6fa4ef9734a7ff0