### PR TITLE
Fix Inno Setup activation error handling

### DIFF
--- a/installer/rankbeam.iss
+++ b/installer/rankbeam.iss
@@ -207,13 +207,10 @@ begin
       GeneratedLicenseKey := ActivateLicense();
       ActivationFailed := False;
     except
-      on E: Exception do
-      begin
-        ActivationFailed := True;
-        GeneratedLicenseKey := '';
-        SuppressibleMsgBox('License activation failed:\n\n' + E.Message + '\n\nYou can rerun the installer or contact support to complete activation.',
-          mbError, MB_OK, IDOK);
-      end;
+      ActivationFailed := True;
+      GeneratedLicenseKey := '';
+      SuppressibleMsgBox('License activation failed:\n\n' + GetExceptionMessage + '\n\nYou can rerun the installer or contact support to complete activation.',
+        mbError, MB_OK, IDOK);
     end;
   end;
 end;


### PR DESCRIPTION
## Summary
- replace the Pascal `on E: Exception do` block with generic error handling in the Inno Setup script
- surface the activation error message using `GetExceptionMessage` so the installer still reports the failure

## Testing
- go build ./... *(fails: missing `gl` pkg-config data and X11 headers in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7047ca3488327b1644a5de4e66362