### PR TITLE
Ensure desktop icon uses embedded app asset

### DIFF
--- a/assets/resources.go
+++ b/assets/resources.go
@@ -7,12 +7,19 @@ import (
 )
 
 //go:embed app.png
-var appScreenshot []byte
+var appIcon []byte
 
-// AppScreenshot returns an embedded preview of the desktop interface.
-func AppScreenshot() fyne.Resource {
-	if len(appScreenshot) == 0 {
+// AppIcon returns the embedded application icon resource.
+func AppIcon() fyne.Resource {
+	if len(appIcon) == 0 {
 		return nil
 	}
-	return fyne.NewStaticResource("app.png", appScreenshot)
+	return fyne.NewStaticResource("app.png", appIcon)
+}
+
+// AppScreenshot returns an embedded preview of the desktop interface.
+// It currently reuses the application icon as a placeholder for marketing
+// screens that expect a screenshot resource.
+func AppScreenshot() fyne.Resource {
+	return AppIcon()
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -21,6 +21,7 @@ import (
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 
+	"github.com/umarmf343/Umar-kdp-product-api/assets"
 	"github.com/umarmf343/Umar-kdp-product-api/internal/scraper"
 )
 
@@ -36,6 +37,10 @@ func Run() {
 	application := app.NewWithID("rankbeam")
 	application.Settings().SetTheme(theme.LightTheme())
 
+	if icon := assets.AppIcon(); icon != nil {
+		application.SetIcon(icon)
+	}
+
 	if lifecycle := application.Lifecycle(); lifecycle != nil {
 		lifecycle.SetOnStopped(func() {
 			if activeService != nil {
@@ -45,6 +50,9 @@ func Run() {
 	}
 
 	window := application.NewWindow("RankBeam")
+	if icon := assets.AppIcon(); icon != nil {
+		window.SetIcon(icon)
+	}
 	window.Resize(fyne.NewSize(1024, 720))
 	window.SetMaster()
 

--- a/main.go
+++ b/main.go
@@ -1,33 +1,7 @@
 package main
 
-import (
-	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/app"
-	"fyne.io/fyne/v2/storage"
-	"fyne.io/fyne/v2/widget"
-	"github.com/umarmf343/Umar-kdp-product-api/internal/ui"
-)
+import "github.com/umarmf343/Umar-kdp-product-api/internal/ui"
 
 func main() {
-	// Create a new Fyne app
-	myApp := app.New()
-
-	// Load the app icon (adjust the path if needed)
-	iconFile := "assets/app.png" // Adjust if your icon is located elsewhere
-	icon, err := fyne.LoadResourceFromPath(iconFile)
-	if err != nil {
-		panic("Icon not found: " + err.Error())
-	}
-
-	// Create the main window
-	myWindow := myApp.NewWindow("RankBeam")
-	myWindow.SetIcon(icon) // Set the app icon
-
-	// Run your original UI logic
 	ui.Run()
-
-	// Show the window and run the app
-	myWindow.Resize(fyne.NewSize(800, 600))
-	myWindow.SetContent(widget.NewLabel("Hello, RankBeam!"))
-	myWindow.ShowAndRun()
 }


### PR DESCRIPTION
## Summary
- expose a reusable AppIcon resource backed by the embedded app.png
- apply the embedded icon to the RankBeam application and main window
- simplify main.go to delegate startup to the UI package

## Testing
- go build ./... *(fails: missing pkg-config entry for gl and X11 headers)*

------
https://chatgpt.com/codex/tasks/task_e_68d73ece2e6483279509d36e7c2359ac