### PR TITLE
Add 30-day expiration to generated licenses

### DIFF
--- a/server/db_test.go
+++ b/server/db_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestLicenseStoreLifecycle(t *testing.T) {
@@ -48,5 +49,54 @@ func TestLicenseStoreLifecycle(t *testing.T) {
 
 	if _, err := store.ValidateLicense(ctx, lic.Key, HashFingerprint("other")); err != ErrFingerprintMismatch {
 		t.Fatalf("expected ErrFingerprintMismatch, got %v", err)
+	}
+}
+
+func TestLicenseExpiration(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "licenses.db")
+
+	store, err := NewLicenseStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewLicenseStore: %v", err)
+	}
+	defer store.Close()
+
+	ctx := context.Background()
+	hash := HashFingerprint("fingerprint")
+
+	lic, created, err := store.CreateLicense(ctx, "CUSTOMER", hash)
+	if err != nil {
+		t.Fatalf("CreateLicense: %v", err)
+	}
+	if !created {
+		t.Fatalf("expected license to be newly created")
+	}
+
+	expiredAt := time.Now().UTC().Add(-31 * 24 * time.Hour)
+	if _, err := store.db.ExecContext(ctx,
+		`UPDATE licenses SET created_at = ? WHERE key = ?`,
+		expiredAt, lic.Key,
+	); err != nil {
+		t.Fatalf("update license timestamp: %v", err)
+	}
+
+	if _, err := store.ValidateLicense(ctx, lic.Key, hash); err != ErrLicenseExpired {
+		t.Fatalf("expected ErrLicenseExpired, got %v", err)
+	}
+
+	refreshed, created, err := store.CreateLicense(ctx, "CUSTOMER", hash)
+	if err != nil {
+		t.Fatalf("CreateLicense after expiry: %v", err)
+	}
+	if !created {
+		t.Fatalf("expected new license to be issued after expiry")
+	}
+	if refreshed.Key == lic.Key {
+		t.Fatalf("expected new license key after expiry")
+	}
+
+	if _, err := store.ValidateLicense(ctx, refreshed.Key, hash); err != nil {
+		t.Fatalf("ValidateLicense after refresh: %v", err)
 	}
 }

--- a/server/license_handler.go
+++ b/server/license_handler.go
@@ -91,6 +91,8 @@ func (h *LicenseHandler) ValidateLicense(w http.ResponseWriter, r *http.Request)
 			http.Error(w, "license not found", http.StatusUnauthorized)
 		case errors.Is(err, ErrFingerprintMismatch):
 			http.Error(w, "fingerprint mismatch", http.StatusUnauthorized)
+		case errors.Is(err, ErrLicenseExpired):
+			http.Error(w, "license expired", http.StatusUnauthorized)
 		default:
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}

--- a/server/license_handler_test.go
+++ b/server/license_handler_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestCreateAndValidateLicense(t *testing.T) {
@@ -92,5 +94,80 @@ func TestUnauthorizedToken(t *testing.T) {
 	handler.CreateLicense(rr, req)
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", rr.Code)
+	}
+}
+
+func TestValidateLicenseExpired(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "licenses.db")
+	store, err := NewLicenseStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewLicenseStore: %v", err)
+	}
+	defer store.Close()
+
+	handler := NewLicenseHandler(store, "secret")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/licenses":
+			handler.CreateLicense(w, r)
+		case "/api/v1/licenses/validate":
+			handler.ValidateLicense(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := server.Client()
+
+	body, _ := json.Marshal(map[string]string{
+		"customerId":  "Acme",
+		"fingerprint": "machine",
+	})
+	req, _ := http.NewRequest(http.MethodPost, server.URL+"/api/v1/licenses", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Installer-Token", "secret")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("create license request error: %v", err)
+	}
+	var createResp map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	resp.Body.Close()
+	key := createResp["licenseKey"]
+	if key == "" {
+		t.Fatal("expected license key in response")
+	}
+
+	if _, err := store.db.ExecContext(context.Background(),
+		`UPDATE licenses SET created_at = ? WHERE key = ?`,
+		time.Now().UTC().Add(-31*24*time.Hour), key,
+	); err != nil {
+		t.Fatalf("update license timestamp: %v", err)
+	}
+
+	valBody, _ := json.Marshal(map[string]string{
+		"licenseKey":  key,
+		"fingerprint": "machine",
+	})
+	req, _ = http.NewRequest(http.MethodPost, server.URL+"/api/v1/licenses/validate", bytes.NewReader(valBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Installer-Token", "secret")
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("validate request error: %v", err)
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	resp.Body.Close()
+	if !bytes.Contains(buf.Bytes(), []byte("license expired")) {
+		t.Fatalf("expected error message about expiration, got %q", buf.String())
 	}
 }


### PR DESCRIPTION
## Summary
- enforce a 30-day validity window for licenses and surface an explicit expiration error
- refresh expired fingerprint records with a new key when issuing a replacement license
- expand store and handler tests to cover expiration scenarios and responses

## Testing
- go test ./server

------
https://chatgpt.com/codex/tasks/task_e_68d74176f52c8327837f1e10dffe0d7b