### PR TITLE
Refactor license server to Paystack subscription flow

### DIFF
--- a/server/db.go
+++ b/server/db.go
@@ -14,18 +14,19 @@ import (
 )
 
 var (
-	ErrLicenseNotFound     = errors.New("license: not found")
-	ErrFingerprintMismatch = errors.New("license: fingerprint mismatch")
-	ErrLicenseExpired      = errors.New("license: expired")
+	ErrLicenseNotFound = errors.New("license: not found")
+	ErrEmailMismatch   = errors.New("license: email mismatch")
+	ErrLicenseExpired  = errors.New("license: expired")
 )
 
 const licenseValidity = 30 * 24 * time.Hour
 
 type License struct {
-	Key             string
-	FingerprintHash string
-	CustomerID      string
-	CreatedAt       time.Time
+	Key            string
+	CustomerEmail  string
+	TransactionRef string
+	ExpiresAt      time.Time
+	CreatedAt      time.Time
 }
 
 type LicenseStore struct {
@@ -56,10 +57,12 @@ func (s *LicenseStore) migrate(ctx context.Context) error {
 	schema := `
 CREATE TABLE IF NOT EXISTS licenses (
     key TEXT PRIMARY KEY,
-    fingerprint_hash TEXT NOT NULL UNIQUE,
-    customer_id TEXT NOT NULL,
+    customer_email TEXT NOT NULL,
+    transaction_ref TEXT NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
     created_at TIMESTAMP NOT NULL
 );
+CREATE INDEX IF NOT EXISTS idx_licenses_email ON licenses(customer_email);
 `
 	if _, err := s.db.ExecContext(ctx, schema); err != nil {
 		return fmt.Errorf("migrate schema: %w", err)
@@ -67,71 +70,31 @@ CREATE TABLE IF NOT EXISTS licenses (
 	return nil
 }
 
-func (s *LicenseStore) CreateLicense(ctx context.Context, customerID, fingerprintHash string) (*License, bool, error) {
-	if existing, err := s.FindByFingerprint(ctx, fingerprintHash); err == nil {
-		now := time.Now().UTC()
-		if now.Sub(existing.CreatedAt) < licenseValidity {
-			return existing, false, nil
-		}
-
-		key, err := GenerateLicenseKey(customerID, fingerprintHash)
-		if err != nil {
-			return nil, false, err
-		}
-		_, err = s.db.ExecContext(ctx,
-			`UPDATE licenses SET key = ?, customer_id = ?, created_at = ? WHERE fingerprint_hash = ?`,
-			key, customerID, now, fingerprintHash,
-		)
-		if err != nil {
-			return nil, false, fmt.Errorf("update license: %w", err)
-		}
-
-		return &License{Key: key, FingerprintHash: fingerprintHash, CustomerID: customerID, CreatedAt: now}, true, nil
-	} else if !errors.Is(err, ErrLicenseNotFound) {
-		return nil, false, err
-	}
-
-	key, err := GenerateLicenseKey(customerID, fingerprintHash)
+func (s *LicenseStore) CreateLicense(ctx context.Context, email, reference string, expiresAt time.Time) (*License, error) {
+	key, err := GenerateLicenseKey(email, reference, expiresAt)
 	if err != nil {
-		return nil, false, err
-	}
-	now := time.Now().UTC()
-	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO licenses(key, fingerprint_hash, customer_id, created_at) VALUES(?, ?, ?, ?)`,
-		key, fingerprintHash, customerID, now,
-	)
-	if err != nil {
-		if sqliteIsConstraint(err) {
-			if existing, findErr := s.FindByFingerprint(ctx, fingerprintHash); findErr == nil {
-				return existing, false, nil
-			}
-		}
-		return nil, false, fmt.Errorf("insert license: %w", err)
-	}
-
-	return &License{Key: key, FingerprintHash: fingerprintHash, CustomerID: customerID, CreatedAt: now}, true, nil
-}
-
-func (s *LicenseStore) FindByFingerprint(ctx context.Context, fingerprintHash string) (*License, error) {
-	row := s.db.QueryRowContext(ctx,
-		`SELECT key, fingerprint_hash, customer_id, created_at FROM licenses WHERE fingerprint_hash = ?`, fingerprintHash,
-	)
-	lic := &License{}
-	if err := row.Scan(&lic.Key, &lic.FingerprintHash, &lic.CustomerID, &lic.CreatedAt); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ErrLicenseNotFound
-		}
 		return nil, err
 	}
-	return lic, nil
+
+	now := time.Now().UTC()
+	email = strings.TrimSpace(strings.ToLower(email))
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO licenses(key, customer_email, transaction_ref, expires_at, created_at) VALUES(?, ?, ?, ?, ?)`,
+		key, email, strings.TrimSpace(reference), expiresAt.UTC(), now,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert license: %w", err)
+	}
+
+	return &License{Key: key, CustomerEmail: email, TransactionRef: reference, ExpiresAt: expiresAt.UTC(), CreatedAt: now}, nil
 }
 
 func (s *LicenseStore) FindByKey(ctx context.Context, key string) (*License, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT key, fingerprint_hash, customer_id, created_at FROM licenses WHERE key = ?`, key,
+		`SELECT key, customer_email, transaction_ref, expires_at, created_at FROM licenses WHERE key = ?`, key,
 	)
 	lic := &License{}
-	if err := row.Scan(&lic.Key, &lic.FingerprintHash, &lic.CustomerID, &lic.CreatedAt); err != nil {
+	if err := row.Scan(&lic.Key, &lic.CustomerEmail, &lic.TransactionRef, &lic.ExpiresAt, &lic.CreatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrLicenseNotFound
 		}
@@ -140,23 +103,23 @@ func (s *LicenseStore) FindByKey(ctx context.Context, key string) (*License, err
 	return lic, nil
 }
 
-func (s *LicenseStore) ValidateLicense(ctx context.Context, key, fingerprintHash string) (*License, error) {
+func (s *LicenseStore) ValidateLicense(ctx context.Context, key, email string) (*License, error) {
 	lic, err := s.FindByKey(ctx, key)
 	if err != nil {
 		return nil, err
 	}
-	if lic.FingerprintHash != fingerprintHash {
-		return nil, ErrFingerprintMismatch
+	if strings.TrimSpace(strings.ToLower(email)) == "" {
+		return nil, fmt.Errorf("email is required")
 	}
-	if time.Now().UTC().Sub(lic.CreatedAt) >= licenseValidity {
+	if !emailsEqual(lic.CustomerEmail, email) {
+		return nil, ErrEmailMismatch
+	}
+	if time.Now().UTC().After(lic.ExpiresAt) {
 		return nil, ErrLicenseExpired
 	}
 	return lic, nil
 }
 
-func sqliteIsConstraint(err error) bool {
-	if err == nil {
-		return false
-	}
-	return strings.Contains(strings.ToLower(err.Error()), "constraint")
+func emailsEqual(stored, provided string) bool {
+	return strings.EqualFold(strings.TrimSpace(stored), strings.TrimSpace(provided))
 }

--- a/server/license_gen.go
+++ b/server/license_gen.go
@@ -1,72 +1,35 @@
 package main
 
 import (
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"strings"
+	"time"
 )
 
-var keyAlphabet = []rune("ABCDEFGHJKLMNPQRSTUVWXYZ23456789")
+func GenerateLicenseKey(email, reference string, expiresAt time.Time) (string, error) {
+	email = strings.TrimSpace(strings.ToLower(email))
+	reference = strings.TrimSpace(reference)
+	if email == "" {
+		return "", fmt.Errorf("email is required")
+	}
+	if reference == "" {
+		return "", fmt.Errorf("transaction reference is required")
+	}
 
-func sanitizeCustomerID(input string) string {
-	cleaned := make([]rune, 0, len(input))
-	for _, r := range strings.ToUpper(input) {
-		if (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
-			cleaned = append(cleaned, r)
-		}
-	}
-	if len(cleaned) == 0 {
-		return "CUSTOMER"
-	}
-	if len(cleaned) > 12 {
-		cleaned = cleaned[:12]
-	}
-	return string(cleaned)
+	emailHash := shortHash(email)
+	refHash := shortHash(reference)
+	expiry := expiresAt.UTC().Format("2006-01-02")
+
+	return fmt.Sprintf("%s%s-%s", emailHash, refHash, expiry), nil
 }
 
-func HashFingerprint(raw string) string {
-	sum := sha256.Sum256([]byte(strings.TrimSpace(raw)))
-	return strings.ToUpper(hex.EncodeToString(sum[:]))
-}
-
-func GenerateLicenseKey(customerID, fingerprintHash string) (string, error) {
-	sanitized := sanitizeCustomerID(customerID)
-	if len(fingerprintHash) < 16 {
-		return "", fmt.Errorf("fingerprint hash too short: %d", len(fingerprintHash))
+func shortHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	encoded := hex.EncodeToString(sum[:])
+	if len(encoded) <= 12 {
+		return encoded
 	}
-	seg1 := fingerprintHash[0:4]
-	seg2 := fingerprintHash[4:8]
-	seg3 := fingerprintHash[8:12]
-	rand1, err := randomSegment(5)
-	if err != nil {
-		return "", err
-	}
-	rand2, err := randomSegment(5)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s-%s-%s-%s-%s-%s", sanitized, seg1, seg2, seg3, rand1, rand2), nil
-}
-
-func randomSegment(length int) (string, error) {
-	if length <= 0 {
-		return "", fmt.Errorf("invalid segment length")
-	}
-	b := make([]rune, length)
-	max := len(keyAlphabet)
-	for i := range b {
-		n, err := rand.Int(rand.Reader, bigInt(max))
-		if err != nil {
-			return "", err
-		}
-		b[i] = keyAlphabet[n.Int64()]
-	}
-	return string(b), nil
-}
-
-func bigInt(n int) *big.Int {
-	return big.NewInt(int64(n))
+	return strings.ToLower(encoded[:12])
 }

--- a/server/license_gen_test.go
+++ b/server/license_gen_test.go
@@ -3,29 +3,35 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
-func TestSanitizeCustomerID(t *testing.T) {
-	got := sanitizeCustomerID(" Acme Corp !123 ")
-	if got != "ACMECORP123" {
-		t.Fatalf("expected ACMECORP123, got %s", got)
-	}
-	got = sanitizeCustomerID("!!!")
-	if got != "CUSTOMER" {
-		t.Fatalf("expected CUSTOMER fallback, got %s", got)
-	}
-}
-
 func TestGenerateLicenseKey(t *testing.T) {
-	hash := HashFingerprint("fingerprint")
-	key, err := GenerateLicenseKey("Example", hash)
+	expiresAt := time.Date(2025, time.October, 1, 0, 0, 0, 0, time.UTC)
+	key, err := GenerateLicenseKey("user@example.com", "PSK_ref", expiresAt)
 	if err != nil {
 		t.Fatalf("GenerateLicenseKey error: %v", err)
 	}
-	if len(key) == 0 {
+	if key == "" {
 		t.Fatal("expected non-empty key")
 	}
-	if !strings.HasPrefix(key, "EXAMPLE") {
-		t.Fatalf("expected prefix to include sanitized customer id, got %s", key)
+	if !strings.HasSuffix(key, "-2025-10-01") {
+		t.Fatalf("expected expiry suffix, got %s", key)
+	}
+
+	parts := strings.SplitN(key, "-", 2)
+	if len(parts[0]) <= 10 {
+		t.Fatalf("expected combined hash prefix, got %s", key)
+	}
+}
+
+func TestGenerateLicenseKeyRequiresFields(t *testing.T) {
+	_, err := GenerateLicenseKey("", "ref", time.Now())
+	if err == nil {
+		t.Fatal("expected error for missing email")
+	}
+	_, err = GenerateLicenseKey("user@example.com", "", time.Now())
+	if err == nil {
+		t.Fatal("expected error for missing reference")
 	}
 }


### PR DESCRIPTION
## Summary
- replace the legacy hardware fingerprint licensing logic with a Paystack-driven subscription model
- add a webhook endpoint that verifies Paystack signatures and issues time-limited license keys for each successful payment
- persist licenses with email and transaction metadata and update validation plus tests for the new format

## Testing
- go test ./server
- go test ./... *(fails: requires OpenGL/X11 system packages for UI build)*

------
https://chatgpt.com/codex/tasks/task_e_68d91f08a0648327ae0977dab0c164d5