### PR TITLE
Harden Paystack license handling and add operator guide

### DIFF
--- a/Paystack licence Guide.txt
+++ b/Paystack licence Guide.txt
@@ -1,0 +1,94 @@
+# Paystack Subscription Licensing Guide
+
+This document explains how the refreshed licensing service issues and validates time-limited keys through Paystack subscription payments. It covers the data flow, how to run the Go service locally, and what operations staff must do to keep the workflow healthy.
+
+## 1. System Overview
+
+1. A customer subscribes via Paystack to the monthly product plan.
+2. Paystack notifies the server by invoking the `/api/v1/paystack/webhook` endpoint.
+3. The server verifies the webhook signature, generates a 30-day license key, stores it in SQLite, and responds with the key/expiry payload.
+4. The desktop installer calls `/api/v1/licenses/validate` with the key plus the purchaser's email. The server checks the expiry timestamp and email match before granting access.
+5. Paystack sends another webhook whenever a subscription renews, repeating step 3 and issuing a fresh key.
+
+The license key format is `emailHash + referenceHash + "-" + expiryDate` (e.g. `3adf19e75290fa83d12c-2025-10-01`). Each component is deterministic so that repeat webhooks for the same payment reuse the same key safely.
+
+## 2. Configuring Paystack
+
+1. Log into your Paystack dashboard and create a **Subscription Plan** for the product (e.g. monthly ₦6,500).
+2. Under **Settings → API Keys & Webhooks**, copy the **Secret Key**. Store it as the `PAYSTACK_SECRET_KEY` in your infrastructure (you will use it when creating payment links through your frontend or desktop app).
+3. Generate a **Webhook Signing Secret**. Paystack signs webhook payloads using your secret key—reuse the Secret Key or create a dedicated secret. Save it as `PAYSTACK_WEBHOOK_SECRET` in the server environment.
+4. Configure the webhook URL in Paystack to point at `https://<your-domain>/api/v1/paystack/webhook`.
+5. Ensure Paystack webhooks include the customer email in `data.customer.email`. That field is required to bind the license to the purchaser.
+
+## 3. Server Environment Variables
+
+| Variable | Description |
+| --- | --- |
+| `LICENSE_BIND_ADDR` | Optional. Custom host:port for the Go HTTP server (defaults to `:8080`). |
+| `LICENSE_DB_PATH` | Optional. Path to the SQLite database file (defaults to `data/licenses.db`). |
+| `LICENSE_API_TOKEN` | Optional. Shared secret that clients must send in `X-Installer-Token` when calling `/api/v1/licenses/validate`. Leave empty to disable token auth. |
+| `PAYSTACK_WEBHOOK_SECRET` | Required in production. Secret used to verify Paystack webhook signatures. |
+
+## 4. Running the Server Locally
+
+```bash
+# Install Go 1.20+ and make sure you have gcc available (modernc sqlite driver compiles C code on first run)
+export LICENSE_DB_PATH="/tmp/licenses.db"
+export PAYSTACK_WEBHOOK_SECRET="dev-secret"
+export LICENSE_API_TOKEN="dev-installer-token"
+go run ./server
+```
+
+The server listens on `http://localhost:8080`. Use `curl` to simulate webhooks:
+
+```bash
+body='{"event":"charge.success","data":{"reference":"TEST123","paid_at":"2024-12-01T10:30:00Z","customer":{"email":"user@example.com"}}}}'
+mac=$(echo -n "$body" | openssl dgst -sha512 -hmac "$PAYSTACK_WEBHOOK_SECRET" | cut -d' ' -f2)
+curl -i -X POST http://localhost:8080/api/v1/paystack/webhook \ 
+  -H "Content-Type: application/json" \ 
+  -H "x-paystack-signature: $mac" \ 
+  --data "$body"
+```
+
+Validate the issued key:
+
+```bash
+curl -i -X POST http://localhost:8080/api/v1/licenses/validate \ 
+  -H "Content-Type: application/json" \ 
+  -H "X-Installer-Token: $LICENSE_API_TOKEN" \ 
+  --data '{"licenseKey":"<returned-key>","email":"user@example.com"}'
+```
+
+## 5. Database Schema & Storage
+
+* Table `licenses`
+  * `key` – Primary key license string returned to clients.
+  * `customer_email` – Lower-cased Paystack customer email.
+  * `transaction_ref` – Paystack transaction reference.
+  * `expires_at` – UTC timestamp 30 days after payment.
+  * `created_at` – UTC timestamp when record was inserted.
+* Index: `idx_licenses_email` for efficient lookups by email if future reporting endpoints need it.
+* The `CreateLicense` helper is idempotent: if Paystack retries the same webhook, the server returns the existing row instead of failing the request.
+
+## 6. Operational Checklist
+
+1. **Backups** – Schedule nightly backups of the SQLite database or migrate to a managed relational database if concurrency grows.
+2. **Monitoring** – Instrument HTTP metrics (e.g. use nginx/ALB logs) to watch webhook response codes. A spike in 4xx/5xx indicates signature or DB issues.
+3. **Rotate Secrets** – Update `PAYSTACK_WEBHOOK_SECRET` periodically. When rotated, update the Paystack dashboard and restart the server with the new value.
+4. **Email Delivery** – Configure an external service (e.g. Amazon SES, SendGrid) to mail license keys after webhook success. Hook into the webhook handler after `CreateLicense` to send the message asynchronously.
+5. **Client Updates** – Ensure the desktop app collects the purchaser's email and license key, includes the installer token header (if enabled), and gracefully handles `401` responses by prompting the user to renew.
+
+## 7. Manual Recovery Steps
+
+* To manually revoke a license, delete the row from the `licenses` table identified by the license key.
+* To issue a one-off replacement, insert a new row with a custom expiry using `sqlite3 licenses.db "INSERT ..."` and email the key to the customer.
+* If Paystack is down, you can temporarily extend a user's access by updating `expires_at` for their key while communicating the temporary measure to the customer.
+
+## 8. Next Actions After Deployment
+
+1. Deploy the updated Go service to your production environment.
+2. Update the desktop/CLI installer so that it hits the new `/api/v1/licenses/validate` endpoint with email + key + optional installer token.
+3. Integrate Paystack subscription checkout into your purchase flow, ensuring the customer's email is captured and sent in the metadata.
+4. Implement the email notification step using your chosen mail provider.
+5. Test end-to-end in a Paystack test environment before switching to live keys.
+

--- a/server/db_test.go
+++ b/server/db_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -18,37 +19,33 @@ func TestLicenseStoreLifecycle(t *testing.T) {
 	defer store.Close()
 
 	ctx := context.Background()
-	hash := HashFingerprint("fingerprint")
+	expiresAt := time.Now().Add(licenseValidity)
 
-	lic, created, err := store.CreateLicense(ctx, "CUSTOMER", hash)
+	lic, created, err := store.CreateLicense(ctx, "user@example.com", "ref-123", expiresAt)
 	if err != nil {
 		t.Fatalf("CreateLicense: %v", err)
 	}
 	if !created {
-		t.Fatalf("expected license to be newly created")
+		t.Fatalf("expected license to be created")
+	}
+	if lic.Key == "" {
+		t.Fatalf("expected license key to be set")
 	}
 
-	lic2, created, err := store.CreateLicense(ctx, "CUSTOMER", hash)
+	fetched, err := store.FindByKey(ctx, lic.Key)
 	if err != nil {
-		t.Fatalf("CreateLicense second call: %v", err)
+		t.Fatalf("FindByKey: %v", err)
 	}
-	if created {
-		t.Fatalf("expected existing license to be returned")
-	}
-	if lic2.Key != lic.Key {
-		t.Fatalf("expected same key, got %s vs %s", lic2.Key, lic.Key)
+	if fetched.CustomerEmail != "user@example.com" {
+		t.Fatalf("expected stored email, got %s", fetched.CustomerEmail)
 	}
 
-	validated, err := store.ValidateLicense(ctx, lic.Key, hash)
-	if err != nil {
+	if _, err := store.ValidateLicense(ctx, lic.Key, "user@example.com"); err != nil {
 		t.Fatalf("ValidateLicense: %v", err)
 	}
-	if validated.Key != lic.Key {
-		t.Fatalf("unexpected validated key %s", validated.Key)
-	}
 
-	if _, err := store.ValidateLicense(ctx, lic.Key, HashFingerprint("other")); err != ErrFingerprintMismatch {
-		t.Fatalf("expected ErrFingerprintMismatch, got %v", err)
+	if _, err := store.ValidateLicense(ctx, lic.Key, "wrong@example.com"); !errors.Is(err, ErrEmailMismatch) {
+		t.Fatalf("expected ErrEmailMismatch, got %v", err)
 	}
 }
 
@@ -63,40 +60,53 @@ func TestLicenseExpiration(t *testing.T) {
 	defer store.Close()
 
 	ctx := context.Background()
-	hash := HashFingerprint("fingerprint")
 
-	lic, created, err := store.CreateLicense(ctx, "CUSTOMER", hash)
+	expiresAt := time.Now().Add(-time.Hour)
+	lic, created, err := store.CreateLicense(ctx, "user@example.com", "ref-123", expiresAt)
 	if err != nil {
 		t.Fatalf("CreateLicense: %v", err)
 	}
 	if !created {
-		t.Fatalf("expected license to be newly created")
+		t.Fatalf("expected license to be created")
 	}
 
-	expiredAt := time.Now().UTC().Add(-31 * 24 * time.Hour)
-	if _, err := store.db.ExecContext(ctx,
-		`UPDATE licenses SET created_at = ? WHERE key = ?`,
-		expiredAt, lic.Key,
-	); err != nil {
-		t.Fatalf("update license timestamp: %v", err)
-	}
-
-	if _, err := store.ValidateLicense(ctx, lic.Key, hash); err != ErrLicenseExpired {
+	if _, err := store.ValidateLicense(ctx, lic.Key, "user@example.com"); !errors.Is(err, ErrLicenseExpired) {
 		t.Fatalf("expected ErrLicenseExpired, got %v", err)
 	}
+}
 
-	refreshed, created, err := store.CreateLicense(ctx, "CUSTOMER", hash)
+func TestCreateLicenseIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "licenses.db")
+
+	store, err := NewLicenseStore(dbPath)
 	if err != nil {
-		t.Fatalf("CreateLicense after expiry: %v", err)
+		t.Fatalf("NewLicenseStore: %v", err)
 	}
-	if !created {
-		t.Fatalf("expected new license to be issued after expiry")
+	defer store.Close()
+
+	ctx := context.Background()
+	expiresAt := time.Now().Add(licenseValidity)
+
+	lic1, created1, err := store.CreateLicense(ctx, "user@example.com", "ref-123", expiresAt)
+	if err != nil {
+		t.Fatalf("CreateLicense: %v", err)
 	}
-	if refreshed.Key == lic.Key {
-		t.Fatalf("expected new license key after expiry")
+	if !created1 {
+		t.Fatalf("expected first call to create a record")
 	}
 
-	if _, err := store.ValidateLicense(ctx, refreshed.Key, hash); err != nil {
-		t.Fatalf("ValidateLicense after refresh: %v", err)
+	lic2, created2, err := store.CreateLicense(ctx, "user@example.com", "ref-123", expiresAt)
+	if err != nil {
+		t.Fatalf("CreateLicense: %v", err)
+	}
+	if created2 {
+		t.Fatalf("expected second call to reuse existing record")
+	}
+	if lic1.Key != lic2.Key {
+		t.Fatalf("expected same license key, got %s vs %s", lic1.Key, lic2.Key)
+	}
+	if !lic1.CreatedAt.Equal(lic2.CreatedAt) {
+		t.Fatalf("expected created timestamp to match")
 	}
 }

--- a/server/license_gen.go
+++ b/server/license_gen.go
@@ -1,72 +1,35 @@
 package main
 
 import (
-	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"strings"
+	"time"
 )
 
-var keyAlphabet = []rune("ABCDEFGHJKLMNPQRSTUVWXYZ23456789")
+func GenerateLicenseKey(email, reference string, expiresAt time.Time) (string, error) {
+	email = strings.TrimSpace(strings.ToLower(email))
+	reference = strings.TrimSpace(reference)
+	if email == "" {
+		return "", fmt.Errorf("email is required")
+	}
+	if reference == "" {
+		return "", fmt.Errorf("transaction reference is required")
+	}
 
-func sanitizeCustomerID(input string) string {
-	cleaned := make([]rune, 0, len(input))
-	for _, r := range strings.ToUpper(input) {
-		if (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
-			cleaned = append(cleaned, r)
-		}
-	}
-	if len(cleaned) == 0 {
-		return "CUSTOMER"
-	}
-	if len(cleaned) > 12 {
-		cleaned = cleaned[:12]
-	}
-	return string(cleaned)
+	emailHash := shortHash(email)
+	refHash := shortHash(reference)
+	expiry := expiresAt.UTC().Format("2006-01-02")
+
+	return fmt.Sprintf("%s%s-%s", emailHash, refHash, expiry), nil
 }
 
-func HashFingerprint(raw string) string {
-	sum := sha256.Sum256([]byte(strings.TrimSpace(raw)))
-	return strings.ToUpper(hex.EncodeToString(sum[:]))
-}
-
-func GenerateLicenseKey(customerID, fingerprintHash string) (string, error) {
-	sanitized := sanitizeCustomerID(customerID)
-	if len(fingerprintHash) < 16 {
-		return "", fmt.Errorf("fingerprint hash too short: %d", len(fingerprintHash))
+func shortHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	encoded := hex.EncodeToString(sum[:])
+	if len(encoded) <= 12 {
+		return encoded
 	}
-	seg1 := fingerprintHash[0:4]
-	seg2 := fingerprintHash[4:8]
-	seg3 := fingerprintHash[8:12]
-	rand1, err := randomSegment(5)
-	if err != nil {
-		return "", err
-	}
-	rand2, err := randomSegment(5)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s-%s-%s-%s-%s-%s", sanitized, seg1, seg2, seg3, rand1, rand2), nil
-}
-
-func randomSegment(length int) (string, error) {
-	if length <= 0 {
-		return "", fmt.Errorf("invalid segment length")
-	}
-	b := make([]rune, length)
-	max := len(keyAlphabet)
-	for i := range b {
-		n, err := rand.Int(rand.Reader, bigInt(max))
-		if err != nil {
-			return "", err
-		}
-		b[i] = keyAlphabet[n.Int64()]
-	}
-	return string(b), nil
-}
-
-func bigInt(n int) *big.Int {
-	return big.NewInt(int64(n))
+	return strings.ToLower(encoded[:12])
 }

--- a/server/license_gen_test.go
+++ b/server/license_gen_test.go
@@ -3,29 +3,35 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
-func TestSanitizeCustomerID(t *testing.T) {
-	got := sanitizeCustomerID(" Acme Corp !123 ")
-	if got != "ACMECORP123" {
-		t.Fatalf("expected ACMECORP123, got %s", got)
-	}
-	got = sanitizeCustomerID("!!!")
-	if got != "CUSTOMER" {
-		t.Fatalf("expected CUSTOMER fallback, got %s", got)
-	}
-}
-
 func TestGenerateLicenseKey(t *testing.T) {
-	hash := HashFingerprint("fingerprint")
-	key, err := GenerateLicenseKey("Example", hash)
+	expiresAt := time.Date(2025, time.October, 1, 0, 0, 0, 0, time.UTC)
+	key, err := GenerateLicenseKey("user@example.com", "PSK_ref", expiresAt)
 	if err != nil {
 		t.Fatalf("GenerateLicenseKey error: %v", err)
 	}
-	if len(key) == 0 {
+	if key == "" {
 		t.Fatal("expected non-empty key")
 	}
-	if !strings.HasPrefix(key, "EXAMPLE") {
-		t.Fatalf("expected prefix to include sanitized customer id, got %s", key)
+	if !strings.HasSuffix(key, "-2025-10-01") {
+		t.Fatalf("expected expiry suffix, got %s", key)
+	}
+
+	parts := strings.SplitN(key, "-", 2)
+	if len(parts[0]) <= 10 {
+		t.Fatalf("expected combined hash prefix, got %s", key)
+	}
+}
+
+func TestGenerateLicenseKeyRequiresFields(t *testing.T) {
+	_, err := GenerateLicenseKey("", "ref", time.Now())
+	if err == nil {
+		t.Fatal("expected error for missing email")
+	}
+	_, err = GenerateLicenseKey("user@example.com", "", time.Now())
+	if err == nil {
+		t.Fatal("expected error for missing reference")
 	}
 }

--- a/server/license_handler.go
+++ b/server/license_handler.go
@@ -1,62 +1,91 @@
 package main
 
 import (
+	"crypto/hmac"
+	"crypto/sha512"
 	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
+	"time"
 )
 
 type LicenseHandler struct {
-	store *LicenseStore
-	token string
+	store         *LicenseStore
+	token         string
+	webhookSecret string
 }
 
-func NewLicenseHandler(store *LicenseStore, token string) *LicenseHandler {
-	return &LicenseHandler{store: store, token: strings.TrimSpace(token)}
+func NewLicenseHandler(store *LicenseStore, token, webhookSecret string) *LicenseHandler {
+	return &LicenseHandler{
+		store:         store,
+		token:         strings.TrimSpace(token),
+		webhookSecret: strings.TrimSpace(webhookSecret),
+	}
 }
 
-func (h *LicenseHandler) CreateLicense(w http.ResponseWriter, r *http.Request) {
+func (h *LicenseHandler) HandlePaystackWebhook(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	if !h.authorize(w, r) {
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "unable to read request body", http.StatusBadRequest)
 		return
 	}
 
-	var payload struct {
-		CustomerID  string `json:"customerId"`
-		Fingerprint string `json:"fingerprint"`
+	if !h.verifySignature(r.Header.Get("x-paystack-signature"), body) {
+		http.Error(w, "invalid signature", http.StatusForbidden)
+		return
 	}
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+
+	var payload paystackEvent
+	if err := json.Unmarshal(body, &payload); err != nil {
 		http.Error(w, "invalid JSON payload", http.StatusBadRequest)
 		return
 	}
-	payload.CustomerID = strings.TrimSpace(payload.CustomerID)
-	payload.Fingerprint = strings.TrimSpace(payload.Fingerprint)
-	if payload.CustomerID == "" || payload.Fingerprint == "" {
-		http.Error(w, "customerId and fingerprint are required", http.StatusBadRequest)
+
+	if !payload.IsSuccessfulEvent() {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ignored"))
 		return
 	}
 
-	hash := HashFingerprint(payload.Fingerprint)
-	sanitized := sanitizeCustomerID(payload.CustomerID)
-	license, created, err := h.store.CreateLicense(r.Context(), sanitized, hash)
+	email := strings.TrimSpace(payload.Data.Customer.Email)
+	reference := strings.TrimSpace(payload.Data.Reference)
+	if email == "" || reference == "" {
+		http.Error(w, "missing customer email or transaction reference", http.StatusBadRequest)
+		return
+	}
+
+	paidAt := payload.Data.PaidAt.Time
+	if payload.Data.PaidAt.IsZero() {
+		paidAt = time.Now().UTC()
+	}
+	expiresAt := paidAt.Add(licenseValidity)
+
+	license, created, err := h.store.CreateLicense(r.Context(), email, reference, expiresAt)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	status := http.StatusOK
 	if created {
 		status = http.StatusCreated
 	}
-	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(map[string]string{"licenseKey": license.Key})
+	json.NewEncoder(w).Encode(map[string]any{
+		"licenseKey": license.Key,
+		"expiresAt":  license.ExpiresAt.Format(time.RFC3339),
+	})
 }
 
 func (h *LicenseHandler) ValidateLicense(w http.ResponseWriter, r *http.Request) {
@@ -70,27 +99,26 @@ func (h *LicenseHandler) ValidateLicense(w http.ResponseWriter, r *http.Request)
 	}
 
 	var payload struct {
-		LicenseKey  string `json:"licenseKey"`
-		Fingerprint string `json:"fingerprint"`
+		LicenseKey string `json:"licenseKey"`
+		Email      string `json:"email"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		http.Error(w, "invalid JSON payload", http.StatusBadRequest)
 		return
 	}
 	payload.LicenseKey = strings.TrimSpace(payload.LicenseKey)
-	payload.Fingerprint = strings.TrimSpace(payload.Fingerprint)
-	if payload.LicenseKey == "" || payload.Fingerprint == "" {
-		http.Error(w, "licenseKey and fingerprint are required", http.StatusBadRequest)
+	payload.Email = strings.TrimSpace(payload.Email)
+	if payload.LicenseKey == "" || payload.Email == "" {
+		http.Error(w, "licenseKey and email are required", http.StatusBadRequest)
 		return
 	}
 
-	hash := HashFingerprint(payload.Fingerprint)
-	if _, err := h.store.ValidateLicense(r.Context(), payload.LicenseKey, hash); err != nil {
+	if _, err := h.store.ValidateLicense(r.Context(), payload.LicenseKey, payload.Email); err != nil {
 		switch {
 		case errors.Is(err, ErrLicenseNotFound):
 			http.Error(w, "license not found", http.StatusUnauthorized)
-		case errors.Is(err, ErrFingerprintMismatch):
-			http.Error(w, "fingerprint mismatch", http.StatusUnauthorized)
+		case errors.Is(err, ErrEmailMismatch):
+			http.Error(w, "email mismatch", http.StatusUnauthorized)
 		case errors.Is(err, ErrLicenseExpired):
 			http.Error(w, "license expired", http.StatusUnauthorized)
 		default:
@@ -113,4 +141,66 @@ func (h *LicenseHandler) authorize(w http.ResponseWriter, r *http.Request) bool 
 	}
 	http.Error(w, "forbidden", http.StatusForbidden)
 	return false
+}
+
+func (h *LicenseHandler) verifySignature(signature string, body []byte) bool {
+	if h.webhookSecret == "" {
+		return true
+	}
+	mac := hmac.New(sha512.New, []byte(h.webhookSecret))
+	mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+	return subtle.ConstantTimeCompare([]byte(strings.TrimSpace(signature)), []byte(expected)) == 1
+}
+
+type paystackEvent struct {
+	Event string          `json:"event"`
+	Data  paystackPayload `json:"data"`
+}
+
+func (e paystackEvent) IsSuccessfulEvent() bool {
+	if strings.EqualFold(e.Event, "charge.success") || strings.EqualFold(e.Event, "invoice.create") || strings.EqualFold(e.Event, "subscription.create") || strings.EqualFold(e.Event, "subscription.renewed") {
+		return true
+	}
+	return false
+}
+
+type paystackPayload struct {
+	Reference string           `json:"reference"`
+	PaidAt    paystackTime     `json:"paid_at"`
+	Customer  paystackCustomer `json:"customer"`
+}
+
+type paystackCustomer struct {
+	Email string `json:"email"`
+}
+
+type paystackTime struct {
+	time.Time
+}
+
+func (pt *paystackTime) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		pt.Time = time.Time{}
+		return nil
+	}
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		pt.Time = time.Time{}
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return err
+	}
+	pt.Time = parsed
+	return nil
+}
+
+func (pt paystackTime) IsZero() bool {
+	return pt.Time.IsZero()
 }

--- a/server/license_handler_test.go
+++ b/server/license_handler_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -11,7 +14,7 @@ import (
 	"time"
 )
 
-func TestCreateAndValidateLicense(t *testing.T) {
+func TestHandlePaystackWebhookCreatesLicense(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "licenses.db")
 	store, err := NewLicenseStore(dbPath)
@@ -20,84 +23,74 @@ func TestCreateAndValidateLicense(t *testing.T) {
 	}
 	defer store.Close()
 
-	handler := NewLicenseHandler(store, "secret")
+	secret := "paystack-secret"
+	handler := NewLicenseHandler(store, "", secret)
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/api/v1/licenses":
-			handler.CreateLicense(w, r)
-		case "/api/v1/licenses/validate":
-			handler.ValidateLicense(w, r)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
+	payload := map[string]any{
+		"event": "charge.success",
+		"data": map[string]any{
+			"reference": "PSK_ref_123",
+			"paid_at":   time.Now().UTC().Format(time.RFC3339),
+			"customer": map[string]any{
+				"email": "user@example.com",
+			},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
 
-	client := server.Client()
-
-	body, _ := json.Marshal(map[string]string{
-		"customerId":  "Acme",
-		"fingerprint": "machine",
-	})
-	req, _ := http.NewRequest(http.MethodPost, server.URL+"/api/v1/licenses", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/paystack/webhook", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Installer-Token", "secret")
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("create license request error: %v", err)
-	}
-	if resp.StatusCode != http.StatusCreated {
-		t.Fatalf("expected status 201, got %d", resp.StatusCode)
-	}
-	var createResp map[string]string
-	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
-		t.Fatalf("decode create response: %v", err)
-	}
-	resp.Body.Close()
-	key := createResp["licenseKey"]
-	if key == "" {
-		t.Fatal("expected license key in response")
-	}
-
-	valBody, _ := json.Marshal(map[string]string{
-		"licenseKey":  key,
-		"fingerprint": "machine",
-	})
-	req, _ = http.NewRequest(http.MethodPost, server.URL+"/api/v1/licenses/validate", bytes.NewReader(valBody))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Installer-Token", "secret")
-	resp, err = client.Do(req)
-	if err != nil {
-		t.Fatalf("validate request error: %v", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-	resp.Body.Close()
-}
-
-func TestUnauthorizedToken(t *testing.T) {
-	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "licenses.db")
-	store, err := NewLicenseStore(dbPath)
-	if err != nil {
-		t.Fatalf("NewLicenseStore: %v", err)
-	}
-	defer store.Close()
-
-	handler := NewLicenseHandler(store, "secret")
-
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/licenses", bytes.NewReader([]byte("{}")))
+	req.Header.Set("x-paystack-signature", signPayload(secret, body))
 	rr := httptest.NewRecorder()
 
-	handler.CreateLicense(rr, req)
+	handler.HandlePaystackWebhook(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rr.Code)
+	}
+
+	var resp struct {
+		LicenseKey string `json:"licenseKey"`
+		ExpiresAt  string `json:"expiresAt"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.LicenseKey == "" {
+		t.Fatal("expected license key in response")
+	}
+	if resp.ExpiresAt == "" {
+		t.Fatal("expected expiry timestamp in response")
+	}
+
+	if _, err := store.ValidateLicense(context.Background(), resp.LicenseKey, "user@example.com"); err != nil {
+		t.Fatalf("ValidateLicense: %v", err)
+	}
+}
+
+func TestValidateLicenseRequiresToken(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "licenses.db")
+	store, err := NewLicenseStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewLicenseStore: %v", err)
+	}
+	defer store.Close()
+
+	handler := NewLicenseHandler(store, "installer-secret", "")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/licenses/validate", bytes.NewReader([]byte(`{"licenseKey":"key","email":"user@example.com"}`)))
+	rr := httptest.NewRecorder()
+
+	handler.ValidateLicense(rr, req)
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", rr.Code)
 	}
 }
 
-func TestValidateLicenseExpired(t *testing.T) {
+func TestValidateLicenseSuccess(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "licenses.db")
 	store, err := NewLicenseStore(dbPath)
@@ -106,68 +99,106 @@ func TestValidateLicenseExpired(t *testing.T) {
 	}
 	defer store.Close()
 
-	handler := NewLicenseHandler(store, "secret")
+	expiresAt := time.Now().Add(licenseValidity)
+	lic, created, err := store.CreateLicense(context.Background(), "user@example.com", "ref-123", expiresAt)
+	if err != nil {
+		t.Fatalf("CreateLicense: %v", err)
+	}
+	if !created {
+		t.Fatalf("expected license to be created")
+	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/api/v1/licenses":
-			handler.CreateLicense(w, r)
-		case "/api/v1/licenses/validate":
-			handler.ValidateLicense(w, r)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-
-	client := server.Client()
+	handler := NewLicenseHandler(store, "installer-secret", "")
 
 	body, _ := json.Marshal(map[string]string{
-		"customerId":  "Acme",
-		"fingerprint": "machine",
+		"licenseKey": lic.Key,
+		"email":      "user@example.com",
 	})
-	req, _ := http.NewRequest(http.MethodPost, server.URL+"/api/v1/licenses", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/licenses/validate", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Installer-Token", "secret")
-	resp, err := client.Do(req)
+	req.Header.Set("X-Installer-Token", "installer-secret")
+	rr := httptest.NewRecorder()
+
+	handler.ValidateLicense(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}
+
+func TestHandlePaystackWebhookInvalidSignature(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "licenses.db")
+	store, err := NewLicenseStore(dbPath)
 	if err != nil {
-		t.Fatalf("create license request error: %v", err)
+		t.Fatalf("NewLicenseStore: %v", err)
 	}
-	var createResp map[string]string
-	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
-		t.Fatalf("decode create response: %v", err)
+	defer store.Close()
+
+	handler := NewLicenseHandler(store, "", "paystack-secret")
+
+	payload := map[string]any{"event": "charge.success", "data": map[string]any{"reference": "ref", "customer": map[string]any{"email": "user@example.com"}}}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/paystack/webhook", bytes.NewReader(body))
+	req.Header.Set("x-paystack-signature", "invalid")
+	rr := httptest.NewRecorder()
+
+	handler.HandlePaystackWebhook(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr.Code)
 	}
-	resp.Body.Close()
-	key := createResp["licenseKey"]
-	if key == "" {
-		t.Fatal("expected license key in response")
+}
+
+func TestHandlePaystackWebhookIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "licenses.db")
+	store, err := NewLicenseStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewLicenseStore: %v", err)
+	}
+	defer store.Close()
+
+	secret := "paystack-secret"
+	handler := NewLicenseHandler(store, "", secret)
+
+	payload := map[string]any{
+		"event": "subscription.renewed",
+		"data": map[string]any{
+			"reference": "PSK_ref_123",
+			"paid_at":   time.Now().UTC().Format(time.RFC3339),
+			"customer": map[string]any{
+				"email": "user@example.com",
+			},
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
 	}
 
-	if _, err := store.db.ExecContext(context.Background(),
-		`UPDATE licenses SET created_at = ? WHERE key = ?`,
-		time.Now().UTC().Add(-31*24*time.Hour), key,
-	); err != nil {
-		t.Fatalf("update license timestamp: %v", err)
+	req1 := httptest.NewRequest(http.MethodPost, "/api/v1/paystack/webhook", bytes.NewReader(body))
+	req1.Header.Set("Content-Type", "application/json")
+	req1.Header.Set("x-paystack-signature", signPayload(secret, body))
+	rr1 := httptest.NewRecorder()
+
+	handler.HandlePaystackWebhook(rr1, req1)
+	if rr1.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rr1.Code)
 	}
 
-	valBody, _ := json.Marshal(map[string]string{
-		"licenseKey":  key,
-		"fingerprint": "machine",
-	})
-	req, _ = http.NewRequest(http.MethodPost, server.URL+"/api/v1/licenses/validate", bytes.NewReader(valBody))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("X-Installer-Token", "secret")
-	resp, err = client.Do(req)
-	if err != nil {
-		t.Fatalf("validate request error: %v", err)
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/paystack/webhook", bytes.NewReader(body))
+	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("x-paystack-signature", signPayload(secret, body))
+	rr2 := httptest.NewRecorder()
+
+	handler.HandlePaystackWebhook(rr2, req2)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("expected 200 for duplicate event, got %d", rr2.Code)
 	}
-	if resp.StatusCode != http.StatusUnauthorized {
-		t.Fatalf("expected 401, got %d", resp.StatusCode)
-	}
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(resp.Body)
-	resp.Body.Close()
-	if !bytes.Contains(buf.Bytes(), []byte("license expired")) {
-		t.Fatalf("expected error message about expiration, got %q", buf.String())
-	}
+}
+
+func signPayload(secret string, body []byte) string {
+	mac := hmac.New(sha512.New, []byte(secret))
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
 }


### PR DESCRIPTION
## Summary
- replace the legacy hardware fingerprint licensing logic with a Paystack-driven subscription model
- add a webhook endpoint that verifies Paystack signatures and issues time-limited license keys for each successful payment
- make license creation idempotent to absorb duplicate Paystack webhooks, expand the automated tests, and ship an operator guide for the new flow

## Testing
- go test ./server
- go test ./... *(fails: requires OpenGL/X11 system packages for UI build)*

------
https://chatgpt.com/codex/tasks/task_e_68d91f08a0648327ae0977dab0c164d5