### PR TITLE
Handle GET requests for Paystack subscription endpoint

### DIFF
--- a/license-api/README.md
+++ b/license-api/README.md
@@ -26,7 +26,9 @@ npm run dev
 ### Starting a subscription
 
 You can kick off a mocked Paystack subscription by sending a `POST` request to the
-`/paystack/subscribe` route:
+`/paystack/subscribe` route. Sending a `GET` request to the same endpoint returns a
+helpful reminder about the required payload, so you can quickly confirm that the
+API is reachable before wiring up the installer:
 
 ```powershell
 Invoke-WebRequest -Uri "http://localhost:8080/paystack/subscribe" `

--- a/license-api/server.js
+++ b/license-api/server.js
@@ -127,6 +127,16 @@ app.get('/health', (req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
 
+app.get('/paystack/subscribe', (req, res) => {
+  res
+    .status(405)
+    .json({
+      error: 'POST required',
+      message:
+        'Send a POST request with JSON body {"email": "user@example.com", "fingerprint": "DEVICE-ID"} to start a subscription.',
+    });
+});
+
 app.post('/paystack/subscribe', async (req, res) => {
   const email = normaliseEmail(req.body?.email);
   const fingerprint = String(req.body?.fingerprint || '').trim();


### PR DESCRIPTION
## Summary
- add a GET handler for /paystack/subscribe that returns a helpful 405 response instead of Express' default HTML
- document the new behaviour in the license API README so developers know how to verify connectivity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db3a262b9c8327bfa569535f6173cf