### PR TITLE
Allow local Paystack webhooks in development

### DIFF
--- a/license-api/README.md
+++ b/license-api/README.md
@@ -67,6 +67,7 @@ that the JSON body is posted correctly.
 - `PAYSTACK_PLAN_CODE` – Paystack plan code used when starting subscriptions.
 - `PAYSTACK_PUBLIC_KEY` – Optional Paystack public key (forwarded in webhook payloads).
 - `PAYSTACK_WEBHOOK_IPS` – Comma-separated list of IPs allowed to call the webhook (defaults to Paystack's IPs).
+- `PAYSTACK_WEBHOOK_ALLOW_LOCAL` – When truthy, automatically whitelists `127.0.0.1`/`::1` for webhook testing (defaults to truthy outside production).
 - `PAYSTACK_USE_MOCK` – When set to a truthy value (e.g. `true`), the API skips real Paystack calls and returns mock responses.
 - `DEBUG_SQLITE_FALLBACK` – Set to a truthy value to log the underlying error when `better-sqlite3` is unavailable.
 


### PR DESCRIPTION
## Summary
- allow opting into local Paystack webhook IPs while keeping production defaults
- normalise configured IPs and document the PAYSTACK_WEBHOOK_ALLOW_LOCAL toggle

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db3d3a68a08327a3e3935b6d45d310