### PR TITLE
Fix license activation upsert column references

### DIFF
--- a/license-api/db.js
+++ b/license-api/db.js
@@ -211,8 +211,8 @@ export function activateLicense({ email, licenseKey, fingerprint, expiresAt, ref
          WHEN excluded.fingerprint IS NULL OR excluded.fingerprint = '' THEN licenses.fingerprint
          ELSE licenses.fingerprint
        END,
-       expires_at=excluded.expiresAt,
-       paystack_reference=COALESCE(excluded.reference, licenses.paystack_reference),
+       expires_at=excluded.expires_at,
+       paystack_reference=COALESCE(excluded.paystack_reference, licenses.paystack_reference),
        status='active',
        updated_at=excluded.updated_at;`,
     { email, licenseKey, fingerprint, expiresAt, reference, now }


### PR DESCRIPTION
## Summary
- fix the ON CONFLICT clause in activateLicense to reference the correct column names when using sql.js fallback
- ensure upsert uses expires_at and paystack_reference columns so the activation request no longer fails

## Testing
- npm --prefix license-api run start

------
https://chatgpt.com/codex/tasks/task_e_68db405645b48327b7212cabc29f00fc