### PR TITLE
Fix expired status update for license validation

### DIFF
--- a/license-api/db.js
+++ b/license-api/db.js
@@ -228,7 +228,7 @@ export function getLicenseByKey(licenseKey) {
   if (row.expires_at) {
     const expiresAt = new Date(row.expires_at);
     if (Number.isFinite(expiresAt.valueOf()) && expiresAt < new Date()) {
-      db.run('UPDATE licenses SET status = "expired", updated_at = ? WHERE id = ?', [new Date().toISOString(), row.id]);
+      db.run("UPDATE licenses SET status = 'expired', updated_at = ? WHERE id = ?", [new Date().toISOString(), row.id]);
       row.status = 'expired';
     }
   }


### PR DESCRIPTION
## Summary
- correct the SQL update for expired licenses to use a string literal so the statement executes

## Testing
- curl -s -X POST http://localhost:8080/paystack/validate -H 'Content-Type: application/json' -H 'X-License-Token: 7c9012993daa2abb40170bab55e1f88d2b24a9601afdec9958a302ce9ba9c43f' -d '{"email":"user@example.com","licenseKey":"B4C9A289323B-AC889919350B-MG5Y6YLD","fingerprint":"DEV-FP-001"}'

------
https://chatgpt.com/codex/tasks/task_e_68db42235b8c83279aa0333848dce4ce