### PR TITLE
Improve licensing API health checks

### DIFF
--- a/license-api/db.js
+++ b/license-api/db.js
@@ -92,6 +92,10 @@ class BetterSqliteAdapter {
     }
     return statement.get();
   }
+
+  ping() {
+    this.db.prepare('SELECT 1').get();
+  }
 }
 
 async function createSqlJsAdapter(dbPath) {
@@ -154,6 +158,10 @@ class SqlJsAdapter {
     const buffer = Buffer.from(data);
     fs.writeFileSync(this.dbPath, buffer);
   }
+
+  ping() {
+    this.db.exec('SELECT 1');
+  }
 }
 
 function bindParams(statement, params) {
@@ -196,6 +204,20 @@ export function savePendingSubscription({ email, licenseKey, fingerprint, refere
        updated_at=excluded.updated_at;`,
     { email, licenseKey, fingerprint, reference, now }
   );
+}
+
+export function databaseHealth() {
+  try {
+    const db = getDb();
+    if (typeof db.ping === 'function') {
+      db.ping();
+    } else {
+      db.get('SELECT 1 AS ok');
+    }
+    return { status: 'ok' };
+  } catch (error) {
+    return { status: 'error', error: error?.message || 'database unavailable' };
+  }
 }
 
 export function activateLicense({ email, licenseKey, fingerprint, expiresAt, reference }) {

--- a/serve guide.txt
+++ b/serve guide.txt
@@ -16,7 +16,8 @@ operational details see `Paystack licence Guide.txt`.
     in good standing and return the current expiry.
   * `POST /paystack/deactivate` – clear the fingerprint so the user can move to
     another machine.
-  * `GET /health` – lightweight heartbeat endpoint.
+* `GET /health` – lightweight heartbeat endpoint that also reports database status.
+* `HEAD /health` – returns `204` when the service and database are ready (ideal for cron jobs).
 * Licences are persisted in `license-api/data/licenses.db` (SQLite) using the
   `better-sqlite3` driver. Fingerprints are required for every validation.
 


### PR DESCRIPTION
## Summary
- add a reusable health snapshot that reports database status for `/health`, `/healthz`, and `/readyz`
- expose database connectivity checks via the SQLite adapters to surface degraded states
- document the enhanced health endpoints in the quickstart guide

## Testing
- node --check server.js

------
https://chatgpt.com/codex/tasks/task_e_68db5064ad508327aee3cb2a613e6bbd