### PR TITLE
feat: add RankBeam landing page with Paystack checkout

### DIFF
--- a/license-api/public/index.html
+++ b/license-api/public/index.html
@@ -1,0 +1,735 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RankBeam – Scale Your Amazon Intelligence</title>
+    <meta
+      name="description"
+      content="Grow your Amazon business with RankBeam. Automate insights, track competitors, and convert more with a seamless Paystack-powered checkout."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['Manrope', 'ui-sans-serif', 'system-ui'],
+            },
+            colors: {
+              brand: {
+                50: '#f6f5ff',
+                100: '#ebe9ff',
+                200: '#d6d4ff',
+                300: '#b3adff',
+                400: '#8b7bff',
+                500: '#6d54ff',
+                600: '#5b36ff',
+                700: '#4a23e0',
+                800: '#3b1ab3',
+                900: '#2e158c',
+              },
+            },
+            boxShadow: {
+              glow: '0 25px 50px -12px rgba(93, 61, 255, 0.45)',
+            },
+            backgroundImage: {
+              'grid-light':
+                'linear-gradient(rgba(109, 84, 255, 0.12) 1px, transparent 1px), linear-gradient(90deg, rgba(109, 84, 255, 0.12) 1px, transparent 1px)',
+            },
+            keyframes: {
+              float: {
+                '0%, 100%': { transform: 'translateY(0px)' },
+                '50%': { transform: 'translateY(-10px)' },
+              },
+              pulseGlow: {
+                '0%, 100%': { opacity: 0.45 },
+                '50%': { opacity: 0.85 },
+              },
+              marquee: {
+                '0%': { transform: 'translateX(0)' },
+                '100%': { transform: 'translateX(-50%)' },
+              },
+            },
+            animation: {
+              float: 'float 6s ease-in-out infinite',
+              pulseGlow: 'pulseGlow 4s ease-in-out infinite',
+              marquee: 'marquee 30s linear infinite',
+            },
+          },
+        },
+      };
+    </script>
+    <style type="text/tailwindcss">
+      body {
+        @apply bg-slate-950 text-slate-100 antialiased;
+      }
+      .hero-gradient {
+        background: radial-gradient(circle at top left, rgba(109, 84, 255, 0.45), transparent 40%),
+          radial-gradient(circle at top right, rgba(56, 189, 248, 0.35), transparent 45%),
+          radial-gradient(circle at bottom, rgba(236, 72, 153, 0.35), transparent 50%);
+      }
+      .frosted {
+        backdrop-filter: blur(18px);
+      }
+      .feature-card:hover .feature-icon {
+        @apply scale-110 rotate-3;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="relative overflow-hidden">
+      <div class="absolute inset-0 hero-gradient opacity-80"></div>
+      <div class="absolute inset-0 bg-grid-light bg-[size:60px_60px] opacity-20 animate-pulseGlow"></div>
+      <div class="relative">
+        <header class="container mx-auto px-6 py-8">
+          <div class="flex items-center justify-between gap-6">
+            <div class="flex items-center gap-3">
+              <span
+                class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-500/20 text-2xl font-black text-brand-200 shadow-glow"
+                >RB</span
+              >
+              <div>
+                <p class="text-lg font-semibold tracking-wide">RankBeam</p>
+                <p class="text-sm text-slate-300">Amazon Growth Intelligence</p>
+              </div>
+            </div>
+            <nav class="hidden items-center gap-8 text-sm font-medium text-slate-200 md:flex">
+              <a href="#features" class="transition hover:text-white">Features</a>
+              <a href="#workflow" class="transition hover:text-white">Workflow</a>
+              <a href="#pricing" class="transition hover:text-white">Pricing</a>
+              <a href="#faq" class="transition hover:text-white">FAQ</a>
+            </nav>
+            <a
+              href="#checkout"
+              class="hidden rounded-full bg-white/10 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-brand-700/30 transition hover:bg-white/15 md:inline-flex"
+            >
+              Start free trial
+            </a>
+          </div>
+        </header>
+
+        <main class="relative">
+          <section class="container mx-auto flex flex-col gap-16 px-6 pb-24 pt-12 lg:flex-row lg:items-center">
+            <div class="max-w-2xl space-y-8">
+              <div class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-brand-100">
+                <span class="h-2 w-2 animate-ping rounded-full bg-emerald-400"></span>
+                Smart Amazon automation
+              </div>
+              <h1 class="text-4xl font-black leading-tight text-white sm:text-5xl lg:text-6xl">
+                Unlock deeper rankings, faster launches, and confident decisions.
+              </h1>
+              <p class="text-lg text-slate-300">
+                RankBeam gives Amazon sellers a real-time cockpit for product intelligence, competitor monitoring, and conversion-boosting automations. Join thousands of brands that grow faster with actionable data.
+              </p>
+              <div class="flex flex-col gap-4 sm:flex-row">
+                <a
+                  href="#checkout"
+                  class="inline-flex items-center justify-center rounded-full bg-brand-500 px-8 py-3 text-base font-semibold text-white shadow-glow transition hover:-translate-y-1 hover:bg-brand-400"
+                >
+                  Subscribe with Paystack
+                </a>
+                <a
+                  href="#workflow"
+                  class="inline-flex items-center justify-center rounded-full border border-white/20 px-8 py-3 text-base font-semibold text-white/80 transition hover:border-white/40 hover:text-white"
+                >
+                  See how it works
+                </a>
+              </div>
+              <dl class="grid gap-6 text-sm text-slate-300 sm:grid-cols-3">
+                <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                  <dt class="text-xs uppercase tracking-wide text-slate-400">Live marketplaces</dt>
+                  <dd class="mt-2 text-2xl font-bold text-white">12+</dd>
+                </div>
+                <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                  <dt class="text-xs uppercase tracking-wide text-slate-400">Avg. ROI</dt>
+                  <dd class="mt-2 text-2xl font-bold text-white">4.8x</dd>
+                </div>
+                <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                  <dt class="text-xs uppercase tracking-wide text-slate-400">Seller community</dt>
+                  <dd class="mt-2 text-2xl font-bold text-white">18k+</dd>
+                </div>
+              </dl>
+            </div>
+            <div class="relative mx-auto w-full max-w-xl">
+              <div class="absolute -left-10 top-10 hidden h-24 w-24 rounded-full bg-brand-500/30 blur-3xl sm:block"></div>
+              <div class="absolute -right-6 -top-12 hidden h-32 w-32 rounded-full bg-cyan-400/20 blur-3xl lg:block"></div>
+              <div class="relative overflow-hidden rounded-3xl border border-white/10 bg-white/10 p-8 shadow-2xl shadow-brand-900/40">
+                <div class="mb-6 flex items-center justify-between text-sm text-slate-300">
+                  <span class="inline-flex items-center gap-2">
+                    <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                    Live keyword velocity
+                  </span>
+                  <span>Last 24h</span>
+                </div>
+                <div class="space-y-4">
+                  <div class="flex items-center justify-between rounded-2xl bg-slate-900/60 p-4 shadow-inner">
+                    <div>
+                      <p class="text-sm font-semibold text-white">Organic rank boost</p>
+                      <p class="text-xs text-slate-400">Auto-adjusted PPC & pricing</p>
+                    </div>
+                    <span class="text-xl font-bold text-emerald-300">+36%</span>
+                  </div>
+                  <div class="flex items-center justify-between rounded-2xl bg-slate-900/60 p-4 shadow-inner">
+                    <div>
+                      <p class="text-sm font-semibold text-white">Conversion uplift</p>
+                      <p class="text-xs text-slate-400">Listing experiments</p>
+                    </div>
+                    <span class="text-xl font-bold text-sky-300">+22%</span>
+                  </div>
+                  <div class="flex items-center justify-between rounded-2xl bg-slate-900/60 p-4 shadow-inner">
+                    <div>
+                      <p class="text-sm font-semibold text-white">Competitor alerts</p>
+                      <p class="text-xs text-slate-400">Repricing triggers</p>
+                    </div>
+                    <span class="text-xl font-bold text-rose-300">42</span>
+                  </div>
+                </div>
+                <div class="mt-8 rounded-2xl border border-white/10 bg-slate-900/70 p-4">
+                  <p class="text-xs uppercase tracking-wider text-slate-400">Trusted by agencies</p>
+                  <div class="mt-4 overflow-hidden">
+                    <div class="flex w-[200%] gap-8 animate-marquee whitespace-nowrap text-sm text-slate-400">
+                      <span>Nova Brands</span>
+                      <span>ScaleGrid Labs</span>
+                      <span>Orion Sellers</span>
+                      <span>MetricHive</span>
+                      <span>Launchlytics</span>
+                      <span>FBA Northstar</span>
+                      <span>Nova Brands</span>
+                      <span>ScaleGrid Labs</span>
+                      <span>Orion Sellers</span>
+                      <span>MetricHive</span>
+                      <span>Launchlytics</span>
+                      <span>FBA Northstar</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section id="features" class="bg-slate-950/70 py-24">
+            <div class="container mx-auto px-6">
+              <div class="mx-auto max-w-3xl text-center">
+                <h2 class="text-3xl font-bold text-white sm:text-4xl">What makes RankBeam unstoppable?</h2>
+                <p class="mt-4 text-lg text-slate-300">
+                  We combine market intelligence, automation, and licensing in one place so you can scale without friction.
+                </p>
+              </div>
+              <div class="mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+                <article class="feature-card group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 transition hover:bg-white/10">
+                  <div
+                    class="feature-icon inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-brand-500/20 text-2xl text-brand-100 transition duration-500"
+                  >
+                    ⚡
+                  </div>
+                  <h3 class="mt-6 text-xl font-semibold text-white">Lightning-fast insights</h3>
+                  <p class="mt-3 text-sm text-slate-300">
+                    Fresh keyword ranks, Buy Box shifts, and category winners every hour so you always react in time.
+                  </p>
+                  <div class="absolute -right-10 top-10 h-24 w-24 rounded-full bg-brand-500/30 blur-3xl transition group-hover:scale-125"></div>
+                </article>
+                <article class="feature-card group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 transition hover:bg-white/10">
+                  <div class="feature-icon inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-cyan-500/20 text-2xl text-cyan-100 transition duration-500">
+                    🤖
+                  </div>
+                  <h3 class="mt-6 text-xl font-semibold text-white">Automation autopilot</h3>
+                  <p class="mt-3 text-sm text-slate-300">
+                    Trigger campaigns, bids, and price changes automatically when RankBeam detects gaps you can own.
+                  </p>
+                  <div class="absolute -right-12 bottom-4 h-20 w-20 rounded-full bg-cyan-400/30 blur-3xl transition group-hover:scale-125"></div>
+                </article>
+                <article class="feature-card group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 transition hover:bg-white/10">
+                  <div class="feature-icon inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-500/20 text-2xl text-emerald-100 transition duration-500">
+                    🔒
+                  </div>
+                  <h3 class="mt-6 text-xl font-semibold text-white">Secure licensing</h3>
+                  <p class="mt-3 text-sm text-slate-300">
+                    Every subscription is bound to your device fingerprint to keep your growth assets protected.
+                  </p>
+                  <div class="absolute -left-6 top-16 h-16 w-16 rounded-full bg-emerald-400/20 blur-3xl transition group-hover:scale-125"></div>
+                </article>
+                <article class="feature-card group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 transition hover:bg-white/10">
+                  <div class="feature-icon inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-rose-500/20 text-2xl text-rose-100 transition duration-500">
+                    📊
+                  </div>
+                  <h3 class="mt-6 text-xl font-semibold text-white">Visual performance boards</h3>
+                  <p class="mt-3 text-sm text-slate-300">
+                    High-clarity dashboards merge your sessions, orders, and marketing data for narrative storytelling.
+                  </p>
+                  <div class="absolute -right-16 top-4 h-28 w-28 rounded-full bg-rose-400/20 blur-3xl transition group-hover:scale-125"></div>
+                </article>
+                <article class="feature-card group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 transition hover:bg-white/10">
+                  <div class="feature-icon inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-amber-500/20 text-2xl text-amber-100 transition duration-500">
+                    🌍
+                  </div>
+                  <h3 class="mt-6 text-xl font-semibold text-white">Global market coverage</h3>
+                  <p class="mt-3 text-sm text-slate-300">
+                    Track all major Amazon marketplaces, including EU & Middle East storefronts, from a single cockpit.
+                  </p>
+                  <div class="absolute -left-16 bottom-0 h-24 w-24 rounded-full bg-amber-400/20 blur-3xl transition group-hover:scale-125"></div>
+                </article>
+                <article class="feature-card group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 transition hover:bg-white/10">
+                  <div class="feature-icon inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-fuchsia-500/20 text-2xl text-fuchsia-100 transition duration-500">
+                    🧠
+                  </div>
+                  <h3 class="mt-6 text-xl font-semibold text-white">AI coaching</h3>
+                  <p class="mt-3 text-sm text-slate-300">
+                    Context-aware prompts highlight what to fix next and generate listing optimisations for you.
+                  </p>
+                  <div class="absolute -right-12 bottom-8 h-16 w-16 rounded-full bg-fuchsia-400/20 blur-3xl transition group-hover:scale-125"></div>
+                </article>
+              </div>
+            </div>
+          </section>
+
+          <section id="workflow" class="relative overflow-hidden py-24">
+            <div class="absolute inset-y-0 -left-32 hidden w-64 rounded-full bg-brand-500/20 blur-3xl lg:block"></div>
+            <div class="absolute inset-y-0 -right-24 hidden w-64 rounded-full bg-cyan-400/20 blur-3xl lg:block"></div>
+            <div class="container mx-auto px-6">
+              <div class="grid items-center gap-16 lg:grid-cols-2">
+                <div class="space-y-6">
+                  <h2 class="text-3xl font-bold text-white sm:text-4xl">From insight to action in three elegant steps.</h2>
+                  <ol class="space-y-6 text-slate-300">
+                    <li class="flex gap-4">
+                      <span class="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-lg font-semibold text-brand-200">1</span>
+                      <div>
+                        <h3 class="text-lg font-semibold text-white">Connect your marketplace</h3>
+                        <p class="text-sm">
+                          Sync ASINs and keywords instantly with secure device licensing. Fingerprints ensure data fidelity.
+                        </p>
+                      </div>
+                    </li>
+                    <li class="flex gap-4">
+                      <span class="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-lg font-semibold text-brand-200">2</span>
+                      <div>
+                        <h3 class="text-lg font-semibold text-white">Automate & monitor</h3>
+                        <p class="text-sm">
+                          Activate automation recipes for PPC, pricing, and review requests. RankBeam watches and reacts.
+                        </p>
+                      </div>
+                    </li>
+                    <li class="flex gap-4">
+                      <span class="flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-lg font-semibold text-brand-200">3</span>
+                      <div>
+                        <h3 class="text-lg font-semibold text-white">Scale with confidence</h3>
+                        <p class="text-sm">
+                          Share live dashboards with teams and investors while RankBeam protects every license in your fleet.
+                        </p>
+                      </div>
+                    </li>
+                  </ol>
+                  <div class="flex flex-wrap items-center gap-6 pt-4 text-sm text-slate-300">
+                    <div class="flex items-center gap-3">
+                      <span class="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-200">★</span>
+                      <span>Paystack secure payments</span>
+                    </div>
+                    <div class="flex items-center gap-3">
+                      <span class="flex h-10 w-10 items-center justify-center rounded-full bg-cyan-500/20 text-cyan-200">⇄</span>
+                      <span>Real-time license validation</span>
+                    </div>
+                    <div class="flex items-center gap-3">
+                      <span class="flex h-10 w-10 items-center justify-center rounded-full bg-rose-500/20 text-rose-200">∞</span>
+                      <span>Unlimited automation recipes</span>
+                    </div>
+                  </div>
+                </div>
+                <div class="relative">
+                  <div class="absolute -left-10 top-8 h-24 w-24 rounded-full bg-brand-500/30 blur-3xl"></div>
+                  <div class="absolute -right-8 bottom-10 h-24 w-24 rounded-full bg-emerald-500/20 blur-3xl"></div>
+                  <div class="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/70 p-8 shadow-glow">
+                    <div class="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-400">
+                      <span>Live session</span>
+                      <span>Automation feed</span>
+                    </div>
+                    <div class="mt-6 space-y-4">
+                      <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                        <div class="flex items-center justify-between">
+                          <p class="text-sm font-semibold text-white">ASIN Rank Recovery</p>
+                          <span class="text-xs text-emerald-300">+14</span>
+                        </div>
+                        <p class="mt-2 text-xs text-slate-400">
+                          Triggered multi-market PPC calibration automatically at 09:15.
+                        </p>
+                      </div>
+                      <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                        <div class="flex items-center justify-between">
+                          <p class="text-sm font-semibold text-white">Listing Optimiser</p>
+                          <span class="text-xs text-sky-300">A/B</span>
+                        </div>
+                        <p class="mt-2 text-xs text-slate-400">
+                          AI copy refresh launched for your hero ASIN to boost conversion rate.
+                        </p>
+                      </div>
+                      <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                        <div class="flex items-center justify-between">
+                          <p class="text-sm font-semibold text-white">Buy Box Shield</p>
+                          <span class="text-xs text-rose-300">NEW</span>
+                        </div>
+                        <p class="mt-2 text-xs text-slate-400">
+                          Competitor price drop matched in 4 minutes. Inventory synced.
+                        </p>
+                      </div>
+                    </div>
+                    <div class="mt-8 flex items-center gap-4 rounded-2xl border border-brand-500/40 bg-brand-500/10 p-4">
+                      <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-500/30 text-2xl text-brand-100 animate-float">
+                        🔄
+                      </div>
+                      <div>
+                        <p class="text-sm font-semibold text-white">RankBeam keeps working, even while you sleep.</p>
+                        <p class="text-xs text-slate-300">Every automation is backed by secure licensing & audit logs.</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section id="pricing" class="bg-slate-900/60 py-24">
+            <div class="container mx-auto px-6">
+              <div class="mx-auto max-w-3xl text-center">
+                <h2 class="text-3xl font-bold text-white sm:text-4xl">Predictable pricing for unstoppable growth.</h2>
+                <p class="mt-4 text-lg text-slate-300">Start with a 14-day risk-free trial. Cancel anytime in two clicks.</p>
+              </div>
+              <div class="mt-16 grid gap-8 lg:grid-cols-3">
+                <div class="flex flex-col gap-6 rounded-3xl border border-white/10 bg-white/5 p-8">
+                  <div class="flex items-center justify-between">
+                    <h3 class="text-xl font-semibold text-white">Starter</h3>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs text-slate-300">Popular</span>
+                  </div>
+                  <p class="text-3xl font-bold text-white">₦29,000<span class="text-base font-medium text-slate-400">/mo</span></p>
+                  <ul class="space-y-3 text-sm text-slate-300">
+                    <li>✔ 50 tracked keywords</li>
+                    <li>✔ 5 ASIN automations</li>
+                    <li>✔ Weekly competitor alerts</li>
+                  </ul>
+                </div>
+                <div class="flex flex-col gap-6 rounded-3xl border border-brand-500/60 bg-brand-500/15 p-8 shadow-glow">
+                  <div class="flex items-center justify-between">
+                    <h3 class="text-xl font-semibold text-white">Scaler</h3>
+                    <span class="rounded-full bg-brand-500/30 px-3 py-1 text-xs text-white">Best value</span>
+                  </div>
+                  <p class="text-3xl font-bold text-white">₦59,000<span class="text-base font-medium text-white/70">/mo</span></p>
+                  <ul class="space-y-3 text-sm text-white/90">
+                    <li>✔ 250 tracked keywords</li>
+                    <li>✔ Unlimited ASIN automations</li>
+                    <li>✔ AI optimisation suite</li>
+                    <li>✔ Dedicated success manager</li>
+                  </ul>
+                </div>
+                <div class="flex flex-col gap-6 rounded-3xl border border-white/10 bg-white/5 p-8">
+                  <div class="flex items-center justify-between">
+                    <h3 class="text-xl font-semibold text-white">Enterprise</h3>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs text-slate-300">Custom</span>
+                  </div>
+                  <p class="text-3xl font-bold text-white">Let’s talk</p>
+                  <ul class="space-y-3 text-sm text-slate-300">
+                    <li>✔ Multi-brand dashboards</li>
+                    <li>✔ Advanced security controls</li>
+                    <li>✔ SLA-backed support</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section id="checkout" class="py-24">
+            <div class="container mx-auto px-6">
+              <div class="grid gap-16 lg:grid-cols-2">
+                <div class="space-y-6">
+                  <div class="inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-emerald-200">
+                    Paystack secured
+                  </div>
+                  <h2 class="text-3xl font-bold text-white sm:text-4xl">Subscribe in under 60 seconds.</h2>
+                  <p class="text-lg text-slate-300">
+                    Complete the form and we’ll redirect you to Paystack to confirm your subscription. Once your payment succeeds, RankBeam activates your license instantly.
+                  </p>
+                  <ul class="space-y-4 text-sm text-slate-300">
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-200">✓</span>
+                      Use the device fingerprint from the RankBeam desktop app.
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-200">✓</span>
+                      You’ll receive your license key immediately after payment.
+                    </li>
+                    <li class="flex items-start gap-3">
+                      <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-200">✓</span>
+                      Cancel anytime from your billing portal—no hidden fees.
+                    </li>
+                  </ul>
+                </div>
+                <div class="relative">
+                  <div class="absolute -left-6 top-6 h-16 w-16 rounded-full bg-brand-500/30 blur-3xl"></div>
+                  <div class="absolute -right-10 bottom-8 h-20 w-20 rounded-full bg-cyan-400/20 blur-3xl"></div>
+                  <div class="relative rounded-3xl border border-white/10 bg-white/10 p-8 shadow-glow">
+                    <form id="subscribeForm" data-api-base="/license-api/paystack" class="space-y-6" autocomplete="off">
+                      <div>
+                        <label for="plan" class="text-sm font-semibold text-white">Choose plan</label>
+                        <select
+                          id="plan"
+                          name="plan"
+                          class="mt-2 w-full rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm text-white focus:border-brand-400 focus:ring-brand-400"
+                        >
+                          <option value="">Scaler – ₦59,000 / month</option>
+                          <option value="STARTER-PLAN">Starter – ₦29,000 / month</option>
+                          <option value="ENTERPRISE-PLAN">Enterprise – custom pricing</option>
+                        </select>
+                      </div>
+                      <div>
+                        <label for="email" class="text-sm font-semibold text-white">Email address</label>
+                        <input
+                          type="email"
+                          id="email"
+                          name="email"
+                          required
+                          placeholder="you@brand.com"
+                          class="mt-2 w-full rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm text-white placeholder:text-slate-500 focus:border-brand-400 focus:ring-brand-400"
+                        />
+                      </div>
+                      <div>
+                        <label for="fingerprint" class="text-sm font-semibold text-white">Device fingerprint</label>
+                        <input
+                          type="text"
+                          id="fingerprint"
+                          name="fingerprint"
+                          required
+                          placeholder="Paste from RankBeam app"
+                          class="mt-2 w-full rounded-2xl border border-white/10 bg-slate-950/80 px-4 py-3 text-sm text-white placeholder:text-slate-500 focus:border-brand-400 focus:ring-brand-400"
+                        />
+                      </div>
+                      <button
+                        type="submit"
+                        class="inline-flex w-full items-center justify-center gap-2 rounded-full bg-brand-500 px-6 py-3 text-sm font-semibold text-white transition hover:bg-brand-400 focus:outline-none focus:ring-2 focus:ring-brand-300 focus:ring-offset-2 focus:ring-offset-slate-950"
+                      >
+                        <span id="submitLabel">Start subscription</span>
+                        <svg
+                          id="submitSpinner"
+                          class="hidden h-4 w-4 animate-spin"
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                        >
+                          <circle
+                            class="opacity-25"
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            stroke="currentColor"
+                            stroke-width="4"
+                          ></circle>
+                          <path
+                            class="opacity-75"
+                            fill="currentColor"
+                            d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                          ></path>
+                        </svg>
+                      </button>
+                      <p id="formMessage" class="hidden text-sm"></p>
+                    </form>
+                    <p class="mt-6 text-xs text-slate-300">
+                      By subscribing you agree to the RankBeam Terms &amp; Conditions and Privacy Policy. Paystack securely processes your payment information.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section id="testimonials" class="bg-slate-900/60 py-24">
+            <div class="container mx-auto px-6">
+              <div class="grid gap-12 lg:grid-cols-3">
+                <div class="lg:col-span-1">
+                  <h2 class="text-3xl font-bold text-white sm:text-4xl">Loved by ambitious Amazon operators.</h2>
+                  <p class="mt-4 text-lg text-slate-300">
+                    Hear from brands that turned RankBeam into their growth engine.
+                  </p>
+                </div>
+                <div class="lg:col-span-2 grid gap-8 md:grid-cols-2">
+                  <blockquote class="rounded-3xl border border-white/10 bg-white/5 p-8">
+                    <p class="text-lg font-semibold text-white">“We scaled to 7-figure revenue in 6 months.”</p>
+                    <p class="mt-4 text-sm text-slate-300">
+                      RankBeam’s automation suite cut our time-to-launch in half and Paystack makes billing painless for our team.
+                    </p>
+                    <footer class="mt-6 text-xs text-slate-400">Ada, Growth Lead @ Stellar Mart</footer>
+                  </blockquote>
+                  <blockquote class="rounded-3xl border border-white/10 bg-white/5 p-8">
+                    <p class="text-lg font-semibold text-white">“The competitor alerts are unreal.”</p>
+                    <p class="mt-4 text-sm text-slate-300">
+                      Our agency manages 20+ brands and RankBeam gives us real-time triggers with secure license control.
+                    </p>
+                    <footer class="mt-6 text-xs text-slate-400">Daniel, CEO @ LaunchPilot</footer>
+                  </blockquote>
+                  <blockquote class="rounded-3xl border border-white/10 bg-white/5 p-8 md:col-span-2">
+                    <p class="text-lg font-semibold text-white">“Instant activation after Paystack checkout.”</p>
+                    <p class="mt-4 text-sm text-slate-300">
+                      Clients get onboarded in minutes. The licensing flow is seamless and support is always responsive.
+                    </p>
+                    <footer class="mt-6 text-xs text-slate-400">Bolu, Head of Ops @ Orbit Sellers</footer>
+                  </blockquote>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section id="faq" class="py-24">
+            <div class="container mx-auto px-6">
+              <div class="mx-auto max-w-3xl text-center">
+                <h2 class="text-3xl font-bold text-white sm:text-4xl">Frequently asked questions</h2>
+                <p class="mt-4 text-lg text-slate-300">
+                  Everything you need to know before starting your RankBeam journey.
+                </p>
+              </div>
+              <div class="mt-16 grid gap-6">
+                <details class="group rounded-3xl border border-white/10 bg-white/5 p-6">
+                  <summary class="flex cursor-pointer items-center justify-between text-left text-lg font-semibold text-white">
+                    How quickly is my license activated?
+                    <span class="ml-4 text-brand-200 transition group-open:rotate-45">＋</span>
+                  </summary>
+                  <p class="mt-4 text-sm text-slate-300">
+                    As soon as Paystack confirms your payment, RankBeam auto-activates your license using the fingerprint you provided. You’ll receive your license key in the confirmation screen and via email.
+                  </p>
+                </details>
+                <details class="group rounded-3xl border border-white/10 bg-white/5 p-6">
+                  <summary class="flex cursor-pointer items-center justify-between text-left text-lg font-semibold text-white">
+                    Can I change my device fingerprint later?
+                    <span class="ml-4 text-brand-200 transition group-open:rotate-45">＋</span>
+                  </summary>
+                  <p class="mt-4 text-sm text-slate-300">
+                    Absolutely. Contact support to deactivate your existing license and generate a fresh activation for the new device—no extra fees.
+                  </p>
+                </details>
+                <details class="group rounded-3xl border border-white/10 bg-white/5 p-6">
+                  <summary class="flex cursor-pointer items-center justify-between text-left text-lg font-semibold text-white">
+                    Does RankBeam work for agencies?
+                    <span class="ml-4 text-brand-200 transition group-open:rotate-45">＋</span>
+                  </summary>
+                  <p class="mt-4 text-sm text-slate-300">
+                    Yes! Agencies manage multiple licenses in a single view, automate recurring tasks, and track every marketplace they serve.
+                  </p>
+                </details>
+                <details class="group rounded-3xl border border-white/10 bg-white/5 p-6">
+                  <summary class="flex cursor-pointer items-center justify-between text-left text-lg font-semibold text-white">
+                    What payment methods does Paystack support?
+                    <span class="ml-4 text-brand-200 transition group-open:rotate-45">＋</span>
+                  </summary>
+                  <p class="mt-4 text-sm text-slate-300">
+                    Paystack accepts local cards, bank transfers, USSD, and mobile money. Everything is encrypted and PCI DSS compliant.
+                  </p>
+                </details>
+              </div>
+            </div>
+          </section>
+        </main>
+
+        <footer class="border-t border-white/10 bg-slate-950/80 py-12">
+          <div class="container mx-auto flex flex-col items-center justify-between gap-6 px-6 text-sm text-slate-400 md:flex-row">
+            <p>© <span id="year"></span> RankBeam. Built for high-growth Amazon sellers.</p>
+            <div class="flex gap-6">
+              <a href="#features" class="transition hover:text-white">Features</a>
+              <a href="#pricing" class="transition hover:text-white">Pricing</a>
+              <a href="mailto:support@rankbeam.hannyshive.com.ng" class="transition hover:text-white">Contact</a>
+            </div>
+          </div>
+        </footer>
+      </div>
+    </div>
+
+    <script>
+      const subscribeForm = document.getElementById('subscribeForm');
+      const messageEl = document.getElementById('formMessage');
+      const submitLabel = document.getElementById('submitLabel');
+      const submitSpinner = document.getElementById('submitSpinner');
+      const yearEl = document.getElementById('year');
+      if (yearEl) {
+        yearEl.textContent = new Date().getFullYear();
+      }
+
+      function setSubmitting(state) {
+        if (state) {
+          submitLabel.textContent = 'Processing...';
+          submitSpinner.classList.remove('hidden');
+          subscribeForm.classList.add('pointer-events-none', 'opacity-80');
+        } else {
+          submitLabel.textContent = 'Start subscription';
+          submitSpinner.classList.add('hidden');
+          subscribeForm.classList.remove('pointer-events-none', 'opacity-80');
+        }
+      }
+
+      function showMessage(type, text) {
+        messageEl.textContent = text;
+        messageEl.className = '';
+        messageEl.classList.add('mt-2', 'rounded-2xl', 'px-4', 'py-3', 'text-sm', 'font-medium');
+        if (type === 'error') {
+          messageEl.classList.add('bg-rose-500/15', 'text-rose-200', 'border', 'border-rose-500/30');
+        } else {
+          messageEl.classList.add('bg-emerald-500/15', 'text-emerald-200', 'border', 'border-emerald-500/30');
+        }
+        messageEl.classList.remove('hidden');
+      }
+
+      async function handleSubscribe(event) {
+        event.preventDefault();
+        const formData = new FormData(subscribeForm);
+        const email = String(formData.get('email') || '').trim();
+        const fingerprint = String(formData.get('fingerprint') || '').trim();
+        const planSelection = String(formData.get('plan') || '').trim();
+
+        if (!email || !fingerprint) {
+          showMessage('error', 'Please provide both your email and device fingerprint.');
+          return;
+        }
+
+        setSubmitting(true);
+        showMessage('success', 'Connecting to Paystack...');
+
+        const apiBase = subscribeForm.dataset.apiBase || '/paystack';
+
+        try {
+          const response = await fetch(`${apiBase}/subscribe`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              email,
+              fingerprint,
+              planCode: planSelection || undefined,
+            }),
+          });
+
+          if (!response.ok) {
+            const errorPayload = await response.json().catch(() => ({ error: 'Unable to start subscription.' }));
+            throw new Error(errorPayload.error || 'Unable to start subscription.');
+          }
+
+          const payload = await response.json();
+          showMessage('success', 'Redirecting you to Paystack to complete payment...');
+
+          if (payload.authorizationUrl) {
+            setTimeout(() => {
+              window.location.href = payload.authorizationUrl;
+            }, 1200);
+          } else {
+            setSubmitting(false);
+            showMessage('success', 'Subscription created. Follow the emailed instructions to activate your license.');
+          }
+        } catch (error) {
+          console.error('Subscription error', error);
+          setSubmitting(false);
+          showMessage('error', error.message || 'Unable to start subscription. Please try again.');
+        }
+      }
+
+      subscribeForm?.addEventListener('submit', handleSubscribe);
+    </script>
+  </body>
+</html>

--- a/license-api/server.js
+++ b/license-api/server.js
@@ -35,6 +35,7 @@ function readBooleanEnv(name, defaultValue = false) {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const PUBLIC_DIR = path.join(__dirname, 'public');
 
 const DEFAULT_INSTALLER_TOKEN =
   '7c9012993daa2abb40170bab55e1f88d2b24a9601afdec9958a302ce9ba9c43f';
@@ -126,6 +127,14 @@ const app = express();
 
 app.use(cors());
 app.use(express.json());
+if (PUBLIC_DIR) {
+  app.use(
+    express.static(PUBLIC_DIR, {
+      extensions: ['html'],
+      maxAge: process.env.NODE_ENV === 'production' ? '1h' : 0,
+    }),
+  );
+}
 
 const PORT = Number(process.env.PORT || process.env.LICENSE_API_PORT || 8080);
 const databasePath = process.env.DATABASE_PATH || path.join(__dirname, 'data', 'licenses.db');
@@ -135,6 +144,12 @@ try {
 } catch (error) {
   console.error('Failed to initialise database', error);
   process.exit(1);
+}
+
+if (PUBLIC_DIR) {
+  app.get('/', (req, res) => {
+    res.sendFile(path.join(PUBLIC_DIR, 'index.html'));
+  });
 }
 
 function normaliseEmail(email) {


### PR DESCRIPTION
## Summary
- add a Tailwind-powered RankBeam marketing and checkout landing page served from the licensing API
- enable Express to serve the new static assets alongside existing Paystack subscription endpoints

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68db567f13f483278f53bbcec32c39da