### PR TITLE
Fix landing page Paystack endpoint base

### DIFF
--- a/license-api/public/index.html
+++ b/license-api/public/index.html
@@ -470,7 +470,7 @@
                   <div class="absolute -left-6 top-6 h-16 w-16 rounded-full bg-brand-500/30 blur-3xl"></div>
                   <div class="absolute -right-10 bottom-8 h-20 w-20 rounded-full bg-cyan-400/20 blur-3xl"></div>
                   <div class="relative rounded-3xl border border-white/10 bg-white/10 p-8 shadow-glow">
-                    <form id="subscribeForm" data-api-base="/license-api/paystack" class="space-y-6" autocomplete="off">
+                    <form id="subscribeForm" data-api-base="./paystack" class="space-y-6" autocomplete="off">
                       <div>
                         <label for="plan" class="text-sm font-semibold text-white">Choose plan</label>
                         <select
@@ -691,7 +691,8 @@
         setSubmitting(true);
         showMessage('success', 'Connecting to Paystack...');
 
-        const apiBase = subscribeForm.dataset.apiBase || '/paystack';
+        const rawApiBase = subscribeForm.dataset.apiBase || './paystack';
+        const apiBase = rawApiBase.replace(/\/+$/, '') || './paystack';
 
         try {
           const response = await fetch(`${apiBase}/subscribe`, {


### PR DESCRIPTION
## Summary
- adjust the sales page Paystack form to use a relative API base so it works when served from the site root
- normalise the configured base path to avoid double slashes when building request URLs

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68db5b967dac83278e71c2a56e7dbf76