### PR TITLE
Align competition and density metrics with title match counts

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -72,7 +72,7 @@ RankBeam opens with a top navigation bar and four main tabs:
 
 This tab combines three complementary actions:
 
-- **Fetch Keyword Suggestions** – Returns search suggestions with estimated volume, competition, and title density.
+- **Fetch Keyword Suggestions** – Returns search suggestions with estimated volume, competition (number of top titles that include the keyword), and title density (count of exact-match titles).
 - **Category Insights** – Highlights categories that align with your seed term.
 - **Bestseller Snapshot** – Analyzes the top-ranking ASINs, including BSR, pricing, and indie-only filtering.
 
@@ -81,8 +81,8 @@ This tab combines three complementary actions:
 2. Select the target marketplace.
 3. Optional: refine filters
    - **Min Search Volume** – Ignore low-volume ideas.
-   - **Max Competition** – Cap the acceptable competition score.
-   - **Max Title Density** – Screen out saturated titles.
+   - **Max Competition** – Cap the acceptable count of titles that include your keyword.
+   - **Max Title Density** – Screen out keywords that already have many exact-match titles.
    - **Max BSR** and **Indie authors only** – Focus bestseller analysis on manageable competition.
 4. Run each action via its dedicated button. Outputs populate the corresponding labeled sections below.
 
@@ -92,7 +92,7 @@ This workspace blends reverse ASIN reconnaissance with campaign planning:
 
 - **Reverse ASIN Intelligence**
   1. Enter a competitor ASIN and marketplace.
-  2. Tune the keyword filters (volume, competition, title density).
+  2. Tune the keyword filters (volume, competition count, title density count).
   3. Click **Run Reverse ASIN** to reveal the highest-leverage keywords that drive the listing.
 
 - **Amazon Ads Planner**

--- a/docs/web-companion/index.html
+++ b/docs/web-companion/index.html
@@ -135,7 +135,7 @@
           <div class="grid gap-4 lg:grid-cols-[0.75fr_1fr]">
             <div class="rounded-2xl border border-slate-800 bg-slate-950/70 p-6 shadow-inner shadow-slate-900/60">
               <h2 class="text-lg font-semibold text-slate-100">Keyword generator</h2>
-              <p class="mt-2 text-sm text-slate-400">These controls reflect the Go/Fyne filters for minimum volume, competition, and title density.</p>
+              <p class="mt-2 text-sm text-slate-400">These controls reflect the Go/Fyne filters for minimum volume, competition count, and title density count.</p>
               <div class="mt-4 grid gap-3 sm:grid-cols-3">
                 <label class="flex flex-col gap-1 text-sm">
                   <span class="text-slate-400">Seed keyword</span>
@@ -146,8 +146,8 @@
                   <input type="number" placeholder="300" class="rounded-xl border border-slate-700 bg-slate-900 px-4 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500" />
                 </label>
                 <label class="flex flex-col gap-1 text-sm">
-                  <span class="text-slate-400">Max competition</span>
-                  <input type="number" placeholder="0.6" class="rounded-xl border border-slate-700 bg-slate-900 px-4 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500" step="0.1" />
+                  <span class="text-slate-400">Max competition count</span>
+                  <input type="number" placeholder="5" class="rounded-xl border border-slate-700 bg-slate-900 px-4 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500" step="1" />
                 </label>
               </div>
               <button class="mt-4 inline-flex items-center gap-2 rounded-xl bg-emerald-400 px-4 py-2 text-sm font-semibold text-emerald-950 shadow shadow-emerald-900/50 transition hover:bg-emerald-300">Generate suggestions</button>

--- a/internal/scraper/fallback.go
+++ b/internal/scraper/fallback.go
@@ -118,15 +118,14 @@ func synthesizeKeywordInsights(seed string, limit int) []KeywordInsight {
 		if search < 120 {
 			search = 120 + idx*5
 		}
-		competition := math.Round((0.18+weight*0.55)*100) / 100
+		contain, exact := estimateTitleMatches(phrase)
 		relevancy := math.Round(math.Max(0.5, 0.92-float64(idx)*0.035+(1-weight)*0.18)*100) / 100
-		density := math.Round((0.22+(1-weight)*0.4)*100) / 100
 		insights = append(insights, KeywordInsight{
 			Keyword:          phrase,
 			SearchVolume:     search,
-			CompetitionScore: competition,
+			CompetitionScore: float64(contain),
 			RelevancyScore:   relevancy,
-			TitleDensity:     density,
+			TitleDensity:     float64(exact),
 		})
 	}
 
@@ -178,7 +177,7 @@ func synthesizeBestsellers(keyword, country string) []BestsellerProduct {
 		asin := fmt.Sprintf("OFFLINE%05d", i+1)
 		bestsellerRank := 350 + i*27 + int(stableFloat(fmt.Sprintf("bsr-%d-%s", i, keyword))*120)
 		indie := i%3 != 0
-		density := math.Round((0.24+stableFloat(fmt.Sprintf("density-%d-%s", i, keyword))*0.5)*100) / 100
+		_, exact := estimateTitleMatches(keyword)
 		url := fmt.Sprintf("https://%s/dp/%s", cfg.Host, asin)
 
 		products = append(products, BestsellerProduct{
@@ -192,7 +191,7 @@ func synthesizeBestsellers(keyword, country string) []BestsellerProduct {
 			BestSeller:   bestsellerRank,
 			Category:     categoryFallbacks[i%len(categoryFallbacks)],
 			IsIndie:      indie,
-			TitleDensity: density,
+			TitleDensity: float64(exact),
 			URL:          url,
 		})
 	}


### PR DESCRIPTION
### **User description**
## Summary
- compute competition and title density from live title match counts and reuse the new estimate in fallbacks
- surface the match counts throughout the UI and exports with updated labels, placeholders, and formatting
- refresh user-facing documentation to describe competition and density as exact title counts

## Testing
- go test ./... *(fails: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68df2c139acc832787ff56443bb5b9d6


___

### **PR Type**
Enhancement


___

### **Description**
- Replace competition and density metrics with exact title match counts

- Update UI labels and placeholders to reflect count-based metrics

- Modify scraping logic to count exact and containing title matches

- Refresh documentation to describe metrics as title counts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Competition Score"] --> B["Title Match Counts"]
  C["Density Score"] --> D["Exact Match Counts"]
  B --> E["UI Updates"]
  D --> E
  E --> F["Documentation Updates"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fallback.go</strong><dd><code>Replace fallback metrics with title match counts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/scraper/fallback.go

<ul><li>Replace competition and density calculations with <br><code>estimateTitleMatches()</code> function<br> <li> Update <code>synthesizeKeywordInsights()</code> to use title match counts instead <br>of scores<br> <li> Modify <code>synthesizeBestsellers()</code> to use exact match counts for title <br>density<br> <li> Add new <code>estimateTitleMatches()</code> function returning containing and exact <br>match counts</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/Umar-kdp-product-api/pull/82/files#diff-94c1c08fd4bafd6e05d7579974b2e321bab9613451e812e4d9f899bccbe77da6">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>service.go</strong><dd><code>Update service methods to use title match counts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/scraper/service.go

<ul><li>Replace <code>computeTitleDensity()</code> calls with <code>computeTitleMatches()</code> <br>throughout service methods<br> <li> Update keyword suggestions to use title match counts for competition <br>and density<br> <li> Modify bestseller analysis to count exact matches instead of <br>calculating density ratios<br> <li> Add fallback logic using <code>estimateTitleMatches()</code> when API calls fail</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/Umar-kdp-product-api/pull/82/files#diff-9a8cab7fe499c96aae944d067274dd0c8609964772018e11d5ad9da826088bc3">+78/-44</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>app.go</strong><dd><code>Update UI to display counts instead of scores</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/ui/app.go

<ul><li>Update placeholder text from "1.0" to "5" for competition fields<br> <li> Add <code>formatCount()</code> function to display counts as integers<br> <li> Update UI labels to reference "competition counts" and "title density <br>counts"<br> <li> Modify export and display functions to use count formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/Umar-kdp-product-api/pull/82/files#diff-13d6b02c08fbba6813cbe62c3475c570c097ca41a75a23b2eece49888e9a7c16">+31/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user-guide.md</strong><dd><code>Update documentation for count-based metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/user-guide.md

<ul><li>Update documentation to describe competition as "number of top titles <br>that include the keyword"<br> <li> Change title density description to "count of exact-match titles"<br> <li> Modify filter descriptions to reference "count" instead of "score"</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/Umar-kdp-product-api/pull/82/files#diff-971a69e5ae264bfdae535d0c72902cc6f15a559f6d2dc650b78b473f6783c3ca">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Update web companion UI for count metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/web-companion/index.html

<ul><li>Update UI labels from "Max competition" to "Max competition count"<br> <li> Change placeholder from "0.6" to "5" for competition input<br> <li> Update description text to reference "competition count" and "title <br>density count"</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/Umar-kdp-product-api/pull/82/files#diff-aa85551a188d24b2b5ebe523fe873640c2a23051114f9900c1bfacff443f3ba5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

