### PR TITLE
Fix settings dialog buttons closing behaviour

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1747,6 +1747,9 @@ func showThrottleSettingsDialog(window fyne.Window) {
 	modal = dialog.NewCustomConfirm("Request Settings", "Save", "Cancel", content, func(ok bool) {
 		if !ok {
 			errorLabel.Hide()
+			if modal != nil {
+				modal.Hide()
+			}
 			return
 		}
 
@@ -1754,11 +1757,16 @@ func showThrottleSettingsDialog(window fyne.Window) {
 		if err != nil {
 			errorLabel.SetText(err.Error())
 			errorLabel.Show()
-			modal.Show()
+			if modal != nil {
+				modal.Show()
+			}
 			return
 		}
 
 		errorLabel.Hide()
+		if modal != nil {
+			modal.Hide()
+		}
 		_, changed := throttleState.Update(time.Duration(timeoutSeconds)*time.Second, requestsPerMinute)
 		if changed {
 			loadMainApplication(win)


### PR DESCRIPTION
## Summary
- ensure cancelling the request settings dialog hides the modal cleanly
- hide the modal after successful saves while keeping validation failures visible

## Testing
- Not run (desktop UI components require a display environment)

------
https://chatgpt.com/codex/tasks/task_e_68df2f0cbce08327bd3e4ff8492c5f20