### PR TITLE
Revamp keyword research layout

### DIFF
--- a/docs/web-companion/index.html
+++ b/docs/web-companion/index.html
@@ -132,59 +132,216 @@
         </section>
 
         <section data-panel="keyword" class="panel hidden space-y-6">
-          <div class="grid gap-4 lg:grid-cols-[0.75fr_1fr]">
-            <div class="rounded-2xl border border-slate-800 bg-slate-950/70 p-6 shadow-inner shadow-slate-900/60">
-              <h2 class="text-lg font-semibold text-slate-100">Keyword generator</h2>
-              <p class="mt-2 text-sm text-slate-400">These controls reflect the Go/Fyne filters for minimum volume, competition count, and title density count.</p>
-              <div class="mt-4 grid gap-3 sm:grid-cols-3">
-                <label class="flex flex-col gap-1 text-sm">
-                  <span class="text-slate-400">Seed keyword</span>
-                  <input type="text" placeholder="gratitude journal" class="rounded-xl border border-slate-700 bg-slate-900 px-4 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500" />
-                </label>
-                <label class="flex flex-col gap-1 text-sm">
-                  <span class="text-slate-400">Min volume</span>
-                  <input type="number" placeholder="300" class="rounded-xl border border-slate-700 bg-slate-900 px-4 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500" />
-                </label>
-                <label class="flex flex-col gap-1 text-sm">
-                  <span class="text-slate-400">Max competition count</span>
-                  <input type="number" placeholder="5" class="rounded-xl border border-slate-700 bg-slate-900 px-4 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500" step="1" />
-                </label>
+          <div class="rounded-2xl border border-slate-800 bg-slate-950/70 p-6 shadow-inner shadow-slate-900/60">
+            <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <p class="text-xs uppercase tracking-[0.35em] text-emerald-300">Keyword Lab</p>
+                <h2 class="mt-1 text-2xl font-semibold text-slate-50">Research Workspace</h2>
+                <p class="mt-2 max-w-2xl text-sm text-slate-400">
+                  Configure the same filters as the desktop client before running a seed search. Presets, filters, and campaign export actions mirror the Go/Fyne keyword toolkit.
+                </p>
               </div>
-              <button class="mt-4 inline-flex items-center gap-2 rounded-xl bg-emerald-400 px-4 py-2 text-sm font-semibold text-emerald-950 shadow shadow-emerald-900/50 transition hover:bg-emerald-300">Generate suggestions</button>
+              <div class="flex flex-wrap gap-2">
+                <button class="inline-flex items-center gap-2 rounded-xl border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-slate-500 hover:text-white">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                  </svg>
+                  Save preset
+                </button>
+                <button class="inline-flex items-center gap-2 rounded-xl border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-slate-500 hover:text-white">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a2.25 2.25 0 00-2.25-2.25h-9A2.25 2.25 0 003 6.75v10.5A2.25 2.25 0 005.25 19.5h9a2.25 2.25 0 002.25-2.25V13.5M9 12h12m0 0l-3-3m3 3l-3 3" />
+                  </svg>
+                  Import CSV
+                </button>
+              </div>
             </div>
-            <div class="rounded-2xl border border-slate-800 bg-slate-950/80 p-6 shadow-lg shadow-slate-950/50">
-              <p class="text-xs uppercase tracking-[0.3em] text-emerald-300">Bestseller snapshot</p>
-              <h3 class="mt-2 text-xl font-semibold text-white">Top 3 competitors</h3>
-              <ol class="mt-4 space-y-3 text-sm text-slate-200">
-                <li class="rounded-xl border border-slate-800 bg-slate-900/70 p-3">1. 5-Minute Gratitude Journal — 2,400 est. sales/mo</li>
-                <li class="rounded-xl border border-slate-800 bg-slate-900/70 p-3">2. Calm Mindfulness Prompts — 1,980 est. sales/mo</li>
-                <li class="rounded-xl border border-slate-800 bg-slate-900/70 p-3">3. Daily Reflection Workbook — 1,540 est. sales/mo</li>
-              </ol>
-              <div class="mt-4 flex flex-wrap gap-2 text-xs text-slate-400">
-                <span class="rounded-full border border-slate-700 px-3 py-1">Export CSV</span>
-                <span class="rounded-full border border-slate-700 px-3 py-1">Copy keywords</span>
-                <span class="rounded-full border border-slate-700 px-3 py-1">Open AMS builder</span>
+
+            <div class="mt-6 grid gap-4 lg:grid-cols-[1.3fr_repeat(3,minmax(0,1fr))]">
+              <label class="flex flex-col gap-1 text-sm">
+                <span class="text-slate-400">Seed keyword</span>
+                <input type="text" placeholder="cyberpunk" class="rounded-xl border border-slate-700 bg-slate-900 px-4 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500" />
+              </label>
+              <label class="flex flex-col gap-1 text-sm">
+                <span class="text-slate-400">Min searches / month</span>
+                <input type="number" placeholder="150" class="rounded-xl border border-slate-700 bg-slate-900 px-4 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500" />
+              </label>
+              <label class="flex flex-col gap-1 text-sm">
+                <span class="text-slate-400">Max competitive score</span>
+                <input type="number" placeholder="45" class="rounded-xl border border-slate-700 bg-slate-900 px-4 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500" />
+              </label>
+              <label class="flex flex-col gap-1 text-sm">
+                <span class="text-slate-400">Title density ceiling</span>
+                <input type="number" placeholder="20" class="rounded-xl border border-slate-700 bg-slate-900 px-4 py-2 text-slate-100 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-500" />
+              </label>
+            </div>
+
+            <div class="mt-4 grid gap-4 md:grid-cols-3">
+              <label class="flex items-center gap-3 rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-3 text-sm text-slate-300">
+                <input type="checkbox" class="h-5 w-5 rounded border-slate-600 bg-slate-800 text-emerald-400 focus:ring-emerald-500" checked />
+                Include bestseller insights
+              </label>
+              <label class="flex items-center gap-3 rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-3 text-sm text-slate-300">
+                <input type="checkbox" class="h-5 w-5 rounded border-slate-600 bg-slate-800 text-emerald-400 focus:ring-emerald-500" checked />
+                Flag compliance risks
+              </label>
+              <label class="flex items-center gap-3 rounded-xl border border-slate-800 bg-slate-900/70 px-4 py-3 text-sm text-slate-300">
+                <input type="checkbox" class="h-5 w-5 rounded border-slate-600 bg-slate-800 text-emerald-400 focus:ring-emerald-500" />
+                Add to AMS queue
+              </label>
+            </div>
+
+            <div class="mt-6 flex flex-col gap-4 border-t border-slate-800 pt-4 sm:flex-row sm:items-center sm:justify-between">
+              <div class="flex flex-wrap items-center gap-3 text-xs text-slate-400">
+                <span class="inline-flex items-center gap-2 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 font-semibold text-emerald-300">
+                  <span class="inline-block h-2 w-2 rounded-full bg-emerald-400"></span>
+                  Ready to fetch suggestions
+                </span>
+                <span>Marketplace: <span class="font-semibold text-slate-200">US</span></span>
+                <span>Preset: <span class="font-semibold text-slate-200">Sci-Fi launch</span></span>
+              </div>
+              <div class="flex flex-wrap gap-2">
+                <button class="inline-flex items-center gap-2 rounded-xl border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-slate-500 hover:text-white">
+                  Reverse ASIN lookup
+                </button>
+                <button class="inline-flex items-center gap-2 rounded-xl bg-emerald-400 px-4 py-2 text-sm font-semibold text-emerald-950 shadow shadow-emerald-900/50 transition hover:bg-emerald-300">
+                  Generate suggestions
+                </button>
               </div>
             </div>
           </div>
 
-          <div class="rounded-2xl border border-slate-800 bg-slate-950/70 p-6 shadow-inner shadow-slate-900/60">
-            <h3 class="text-lg font-semibold text-slate-100">Category intelligence</h3>
-            <p class="mt-2 text-sm text-slate-400">Display trending KDP niches exactly like the desktop analytics cards.</p>
-            <div class="mt-4 grid gap-4 md:grid-cols-3">
-              <div class="rounded-xl border border-slate-800 bg-slate-900/70 p-4">
-                <p class="text-xs uppercase tracking-wide text-slate-400">Highest momentum</p>
-                <p class="mt-1 text-lg font-semibold text-white">Self-care &amp; Wellness</p>
-                <p class="mt-2 text-sm text-emerald-300">▲ 18% month over month</p>
+          <div class="rounded-2xl border border-slate-800 bg-slate-950/80 p-6 shadow-2xl shadow-slate-950/60">
+            <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <p class="text-xs uppercase tracking-[0.35em] text-emerald-300">Results</p>
+                <h3 class="mt-1 text-xl font-semibold text-white">Keyword suggestions</h3>
+                <p class="mt-2 text-sm text-slate-400">A quick-look table styled after Publisher Rocket—metrics sync with the desktop analyzer.</p>
               </div>
-              <div class="rounded-xl border border-slate-800 bg-slate-900/70 p-4">
-                <p class="text-xs uppercase tracking-wide text-slate-400">Indie opportunity</p>
-                <p class="mt-1 text-lg font-semibold text-white">Guided Mindfulness Workbooks</p>
-                <p class="mt-2 text-sm text-slate-400">Average rank 6,200 with 40% indie share</p>
+              <div class="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+                <div class="flex flex-1 items-center gap-2 rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-200">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35M4.5 10.5a6 6 0 1112 0 6 6 0 01-12 0z" />
+                  </svg>
+                  <input type="text" placeholder="Filter keywords" class="w-full bg-transparent text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none" />
+                </div>
+                <button class="inline-flex items-center justify-center gap-2 rounded-xl bg-amber-400 px-4 py-2 text-sm font-semibold text-amber-950 shadow shadow-amber-900/40 transition hover:bg-amber-300">
+                  + New search
+                </button>
+                <button class="inline-flex items-center justify-center gap-2 rounded-xl border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-slate-500 hover:text-white">
+                  Export
+                </button>
               </div>
-              <div class="rounded-xl border border-slate-800 bg-slate-900/70 p-4">
-                <p class="text-xs uppercase tracking-wide text-slate-400">Compliance watch</p>
-                <p class="mt-1 text-lg font-semibold text-white">Stay clear of trademarked phrases like "Calm®"</p>
+            </div>
+
+            <div class="mt-6 overflow-x-auto">
+              <table class="w-full table-auto border-collapse text-left text-sm">
+                <thead class="bg-slate-900/80 text-xs uppercase tracking-wide text-slate-400">
+                  <tr>
+                    <th class="px-4 py-3 font-semibold">Keyword</th>
+                    <th class="px-4 py-3 font-semibold">Average pages</th>
+                    <th class="px-4 py-3 font-semibold">Competitors</th>
+                    <th class="px-4 py-3 font-semibold">Average price</th>
+                    <th class="px-4 py-3 font-semibold">Monthly earnings</th>
+                    <th class="px-4 py-3 font-semibold">Amazon searches/mo</th>
+                    <th class="px-4 py-3 font-semibold">Competitive score</th>
+                    <th class="px-4 py-3 font-semibold">Action</th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-800 bg-slate-950/60 text-slate-100">
+                  <tr class="transition hover:bg-slate-900/70">
+                    <td class="px-4 py-3 font-medium text-white">cyberpunk</td>
+                    <td class="px-4 py-3">220</td>
+                    <td class="px-4 py-3">15,047</td>
+                    <td class="px-4 py-3">$9</td>
+                    <td class="px-4 py-3">$113</td>
+                    <td class="px-4 py-3">
+                      <span class="inline-flex items-center rounded-full bg-rose-500/10 px-3 py-1 text-xs font-semibold text-rose-300 ring-1 ring-inset ring-rose-500/40">&lt; 100</span>
+                    </td>
+                    <td class="px-4 py-3">
+                      <span class="inline-flex items-center rounded-full bg-rose-500/10 px-3 py-1 text-xs font-semibold text-rose-300 ring-1 ring-inset ring-rose-500/40">70</span>
+                    </td>
+                    <td class="px-4 py-3">
+                      <button class="rounded-lg bg-emerald-400/90 px-3 py-1 text-xs font-semibold text-emerald-950 shadow-inner shadow-emerald-900/60 transition hover:bg-emerald-300">Details</button>
+                    </td>
+                  </tr>
+                  <tr class="transition hover:bg-slate-900/70">
+                    <td class="px-4 py-3 font-medium text-white">cyberpunk 2077</td>
+                    <td class="px-4 py-3">51</td>
+                    <td class="px-4 py-3">86</td>
+                    <td class="px-4 py-3">$8</td>
+                    <td class="px-4 py-3">$135</td>
+                    <td class="px-4 py-3">
+                      <span class="inline-flex items-center rounded-full bg-rose-500/10 px-3 py-1 text-xs font-semibold text-rose-300 ring-1 ring-inset ring-rose-500/40">&lt; 100</span>
+                    </td>
+                    <td class="px-4 py-3">
+                      <span class="inline-flex items-center rounded-full bg-amber-400/10 px-3 py-1 text-xs font-semibold text-amber-300 ring-1 ring-inset ring-amber-400/40">50</span>
+                    </td>
+                    <td class="px-4 py-3">
+                      <button class="rounded-lg bg-emerald-400/90 px-3 py-1 text-xs font-semibold text-emerald-950 shadow-inner shadow-emerald-900/60 transition hover:bg-emerald-300">Details</button>
+                    </td>
+                  </tr>
+                  <tr class="rounded-xl border border-amber-400/50 bg-slate-900/80 shadow-inner shadow-amber-900/20 transition hover:bg-slate-900">
+                    <td class="px-4 py-3 font-semibold text-amber-200">cyberpunk novels</td>
+                    <td class="px-4 py-3">343</td>
+                    <td class="px-4 py-3">7,643</td>
+                    <td class="px-4 py-3">$7</td>
+                    <td class="px-4 py-3">$773</td>
+                    <td class="px-4 py-3">
+                      <span class="inline-flex items-center rounded-full bg-rose-500/10 px-3 py-1 text-xs font-semibold text-rose-300 ring-1 ring-inset ring-rose-500/40">339</span>
+                    </td>
+                    <td class="px-4 py-3">
+                      <span class="inline-flex items-center rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-semibold text-emerald-300 ring-1 ring-inset ring-emerald-400/40">20</span>
+                    </td>
+                    <td class="px-4 py-3">
+                      <button class="rounded-lg bg-emerald-400/90 px-3 py-1 text-xs font-semibold text-emerald-950 shadow-inner shadow-emerald-900/60 transition hover:bg-emerald-300">Details</button>
+                    </td>
+                  </tr>
+                  <tr class="transition hover:bg-slate-900/70">
+                    <td class="px-4 py-3 font-medium text-white">cyberpunk romance</td>
+                    <td class="px-4 py-3">198</td>
+                    <td class="px-4 py-3">3,412</td>
+                    <td class="px-4 py-3">$11</td>
+                    <td class="px-4 py-3">$420</td>
+                    <td class="px-4 py-3">
+                      <span class="inline-flex items-center rounded-full bg-amber-400/10 px-3 py-1 text-xs font-semibold text-amber-300 ring-1 ring-inset ring-amber-400/40">1,240</span>
+                    </td>
+                    <td class="px-4 py-3">
+                      <span class="inline-flex items-center rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-semibold text-emerald-300 ring-1 ring-inset ring-emerald-400/40">32</span>
+                    </td>
+                    <td class="px-4 py-3">
+                      <button class="rounded-lg bg-emerald-400/90 px-3 py-1 text-xs font-semibold text-emerald-950 shadow-inner shadow-emerald-900/60 transition hover:bg-emerald-300">Details</button>
+                    </td>
+                  </tr>
+                  <tr class="transition hover:bg-slate-900/70">
+                    <td class="px-4 py-3 font-medium text-white">cyberpunk coloring book</td>
+                    <td class="px-4 py-3">112</td>
+                    <td class="px-4 py-3">1,275</td>
+                    <td class="px-4 py-3">$12</td>
+                    <td class="px-4 py-3">$268</td>
+                    <td class="px-4 py-3">
+                      <span class="inline-flex items-center rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-semibold text-emerald-300 ring-1 ring-inset ring-emerald-400/40">2,410</span>
+                    </td>
+                    <td class="px-4 py-3">
+                      <span class="inline-flex items-center rounded-full bg-emerald-400/10 px-3 py-1 text-xs font-semibold text-emerald-300 ring-1 ring-inset ring-emerald-400/40">18</span>
+                    </td>
+                    <td class="px-4 py-3">
+                      <button class="rounded-lg bg-emerald-400/90 px-3 py-1 text-xs font-semibold text-emerald-950 shadow-inner shadow-emerald-900/60 transition hover:bg-emerald-300">Details</button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="mt-4 flex flex-col gap-3 border-t border-slate-800 pt-4 text-xs text-slate-400 sm:flex-row sm:items-center sm:justify-between">
+              <div class="flex flex-wrap items-center gap-3">
+                <span class="rounded-full border border-slate-700 px-3 py-1">5 keyword ideas</span>
+                <span class="rounded-full border border-slate-700 px-3 py-1">Avg. earnings $342</span>
+                <span class="rounded-full border border-slate-700 px-3 py-1">Best score 18</span>
+              </div>
+              <div class="flex flex-wrap items-center gap-2 text-slate-300">
+                <button class="rounded-lg border border-slate-700 px-3 py-1 transition hover:border-slate-500 hover:text-white">Copy table</button>
+                <button class="rounded-lg border border-slate-700 px-3 py-1 transition hover:border-slate-500 hover:text-white">Send to AMS</button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### **User description**
## Summary
- redesign the keyword research tab to mirror the Publisher Rocket inspired layout with Tailwind components
- add toolbar controls, filter inputs, and badge-styled metrics to align with the desktop workflow narrative

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e218d02a2c8327b74d1c0ddb650de7


___

### **PR Type**
Enhancement


___

### **Description**
- Complete redesign of keyword research interface with Publisher Rocket inspired layout

- Added comprehensive toolbar controls, filter inputs, and badge-styled metrics

- Implemented detailed keyword results table with competitive scoring system

- Enhanced user experience with modern Tailwind components and improved workflow


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Simple Layout"] --> B["Research Workspace"]
  B --> C["Filter Controls"]
  B --> D["Keyword Results Table"]
  C --> E["Badge Metrics"]
  D --> F["Competitive Scoring"]
  D --> G["Export Actions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Complete keyword research interface overhaul</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/web-companion/index.html

<ul><li>Completely redesigned keyword research section with modern layout<br> <li> Added comprehensive filter controls and toolbar buttons<br> <li> Implemented detailed keyword results table with competitive metrics<br> <li> Enhanced UI with badge-styled status indicators and action buttons</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/Umar-kdp-product-api/pull/84/files#diff-aa85551a188d24b2b5ebe523fe873640c2a23051114f9900c1bfacff443f3ba5">+202/-45</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

