### PR TITLE
Fix keyword research results overlay

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -675,6 +675,7 @@ func buildKeywordResearchTab(window fyne.Window, service *scraper.Service, count
 	keywordTableContainer := container.NewPadded(keywordTable)
 	keywordTableContainer.Hide()
 	keywordStatusContainer := container.NewPadded(keywordLabel)
+	keywordResultStack := container.NewStack(keywordTableContainer, keywordStatusContainer)
 
 	categoryControls := container.NewHBox()
 	categoryControls.Hide()
@@ -756,6 +757,7 @@ func buildKeywordResearchTab(window fyne.Window, service *scraper.Service, count
 		keywordControls.Hide()
 		keywordTableContainer.Hide()
 		keywordStatusContainer.Show()
+		keywordResultStack.Refresh()
 		keywordTableData = keywordTableData[:0]
 		keywordTable.Refresh()
 
@@ -790,6 +792,7 @@ func buildKeywordResearchTab(window fyne.Window, service *scraper.Service, count
 					keywordTableContainer.Hide()
 					keywordTable.Refresh()
 					keywordStatusContainer.Show()
+					keywordResultStack.Refresh()
 					return
 				}
 				keywordTableData = append(keywordTableData[:0], insights...)
@@ -800,6 +803,7 @@ func buildKeywordResearchTab(window fyne.Window, service *scraper.Service, count
 				keywordTableContainer.Show()
 				keywordTable.Refresh()
 				keywordStatusContainer.Hide()
+				keywordResultStack.Refresh()
 				safeSet(keywordResult, keywordSummaryMessage(len(keywordTableData)))
 			})
 		}()
@@ -1003,8 +1007,7 @@ func buildKeywordResearchTab(window fyne.Window, service *scraper.Service, count
 	keywordTabContent := newResultScroll(container.NewVBox(
 		keywordHeader,
 		widget.NewSeparator(),
-		keywordTableContainer,
-		keywordStatusContainer,
+		keywordResultStack,
 	))
 
 	categoryTabContent := newResultScroll(container.NewVBox(


### PR DESCRIPTION
### **User description**
## Summary
- wrap the keyword results table and status label in a stacked container so the placeholder no longer covers fetched data
- refresh the stacked container whenever keyword results state changes to keep the UI in sync

## Testing
- go test ./... *(fails: missing OpenGL/X11 development libraries in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2284823dc832797126b93710b09c9


___

### **PR Type**
Bug fix


___

### **Description**
- Fix keyword results overlay issue in research tab

- Wrap table and status in stacked container

- Add refresh calls to keep UI synchronized


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Separate Containers"] --> B["Stacked Container"]
  B --> C["UI Refresh Calls"]
  C --> D["Fixed Overlay Issue"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.go</strong><dd><code>Fix keyword results overlay with stacked container</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/ui/app.go

<ul><li>Create stacked container combining keyword table and status containers<br> <li> Add refresh calls after showing/hiding containers to sync UI state<br> <li> Replace separate container placement with single stacked container in <br>layout</ul>


</details>


  </td>
  <td><a href="https://github.com/umarmf343/Umar-kdp-product-api/pull/88/files#diff-13d6b02c08fbba6813cbe62c3475c570c097ca41a75a23b2eece49888e9a7c16">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

