### PR TITLE
Fix competition badge scaling for desktop keyword table

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -1744,21 +1744,19 @@ func buildProductCards(details *scraper.ProductDetails) []fyne.CanvasObject {
 }
 
 func keywordCompetitionBadge(score float64) string {
-	scaled := int(math.Round(score * 10))
-	if scaled < 0 {
-		scaled = 0
-	}
-	if scaled > 100 {
-		scaled = 100
+	rounded := int(math.Round(score))
+	if rounded < 0 {
+		rounded = 0
 	}
 
+	value := formatCount(float64(rounded))
 	switch {
-	case scaled <= 30:
-		return fmt.Sprintf("🟢 %d", scaled)
-	case scaled <= 60:
-		return fmt.Sprintf("🟡 %d", scaled)
+	case rounded <= 100:
+		return fmt.Sprintf("🟢 %s", value)
+	case rounded <= 400:
+		return fmt.Sprintf("🟡 %s", value)
 	default:
-		return fmt.Sprintf("🔴 %d", scaled)
+		return fmt.Sprintf("🔴 %s", value)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep the keyword competition badge based on the raw competitor count instead of a normalized 0-100 scale
- bucket the count into low/medium/high ranges while preserving the displayed value

## Testing
- not run (fails in this environment because go test ./... requires OpenGL/X11 headers)


------
https://chatgpt.com/codex/tasks/task_e_68e582d8df7c83278f3844ba176525a0